### PR TITLE
Removes a `println!` call from keyfile.rs

### DIFF
--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -48,7 +48,5 @@ pub fn parse(source: &mut std::io::Read) -> Result<Vec<u8>> {
         buffer.extend(v);
     }
 
-    println!("Keyfile parsed: {:?}", buffer);
-
     Ok(buffer)
 }


### PR DESCRIPTION
Maybe this was leftover from debugging?