### PR TITLE
Fix Clippy lints

### DIFF
--- a/src/parse/kdb.rs
+++ b/src/parse/kdb.rs
@@ -42,7 +42,7 @@ fn parse_header(data: &[u8]) -> Result<KDBHeader> {
     }
 
     Ok(KDBHeader {
-        version: version,
+        version,
         flags: LittleEndian::read_u32(&data[8..]),
         subversion: LittleEndian::read_u32(&data[12..]),
         master_seed: data[16..32].to_vec(),
@@ -154,7 +154,7 @@ fn parse_groups(root: &mut Group, header_num_groups: u32, data: &mut &[u8]) -> R
                 // Update the current group tree branch (collapse previous sub-branch, initiate
                 // current sub-branch)
                 if level < branch.len() {
-                    group_path.split_off(level);
+                    group_path.truncate(level);
                     collapse_tail_groups(&mut branch, level, root);
                 }
                 if level == branch.len() {

--- a/src/result.rs
+++ b/src/result.rs
@@ -205,11 +205,11 @@ impl std::fmt::Display for DatabaseIntegrityError {
                 DatabaseIntegrityError::InvalidKDBEntryFieldType { field_type } =>
                     format!("Encountered an invalid entry field type: {}", field_type),
                 DatabaseIntegrityError::MissingKDBGroupId =>
-                    format!("Encountered a group/entry without a GroupId"),
+                    "Encountered a group/entry without a GroupId".to_string(),
                 DatabaseIntegrityError::InvalidKDBGroupId { group_id } =>
                     format!("Encountered an entry with an invalid GroupId: {}", group_id),
                 DatabaseIntegrityError::MissingKDBGroupLevel =>
-                    format!("Encountered a group without a Level"),
+                    "Encountered a group without a Level".to_string(),
                 DatabaseIntegrityError::InvalidKDBGroupLevel {
                     group_level,
                     current_level,
@@ -218,11 +218,11 @@ impl std::fmt::Display for DatabaseIntegrityError {
                     group_level, current_level
                 ),
                 DatabaseIntegrityError::IncompleteKDBGroup =>
-                    format!("Encountered an incomplete group"),
+                    "Encountered an incomplete group".to_string(),
                 DatabaseIntegrityError::IncompleteKDBEntry =>
-                    format!("Encountered an incomplete entry"),
+                    "Encountered an incomplete entry".to_string(),
                 DatabaseIntegrityError::MissingKDBEntryTitle =>
-                    format!("Encountered an entry without a title"),
+                    "Encountered an entry without a title".to_string(),
                 DatabaseIntegrityError::XMLParsing { e } => format!(
                     "Encountered an error when parsing the inner XML payload: {}",
                     e


### PR DESCRIPTION
* Remove unneeded formats, prefer .to_string()
* Remove redundant field name in struct
* Satisfied must_use by discarding other half of vec explicitly rather
  than implicitly