### PR TITLE
Fix dead doc link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 homepage = "https://github.com/sseemayer/keepass-rs"
 repository = "https://github.com/sseemayer/keepass-rs"
-documentation = "https://sseemayer.github.io/keepass-rs/"
+documentation = "https://docs.rs/keepass"
 
 version = "0.4.8"
 authors = ["Stefan Seemayer <stefan@seemayer.de>"]


### PR DESCRIPTION
Crates.io points to https://sseemayer.github.io/keepass-rs/ for documentation in the sidebar but link seems dead.
I think it's grabbing the info in Cargo.toml, so updating it.