### PR TITLE
Fix KDBX4 key calculation on 32 bit platforms

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -30,3 +30,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test --release --target armv7-unknown-linux-musleabihf tests::kdbx4_entry

--- a/src/hmac_block_stream.rs
+++ b/src/hmac_block_stream.rs
@@ -10,7 +10,7 @@ pub(crate) fn read_hmac_block_stream(data: &[u8], key: &GenericArray<u8, U64>) -
     let mut out = Vec::new();
 
     let mut pos = 0;
-    let mut block_index = 0;
+    let mut block_index: u64 = 0;
 
     while pos < data.len() {
         let hmac = &data[pos..(pos + 32)];
@@ -43,7 +43,7 @@ pub(crate) fn read_hmac_block_stream(data: &[u8], key: &GenericArray<u8, U64>) -
 }
 
 pub(crate) fn get_hmac_block_key(
-    block_index: usize,
+    block_index: u64,
     key: &GenericArray<u8, U64>,
 ) -> Result<GenericArray<u8, U64>> {
     let mut buf = [0u8; 8];

--- a/src/parse/kdbx4.rs
+++ b/src/parse/kdbx4.rs
@@ -272,7 +272,7 @@ pub(crate) fn decrypt_xml(
 
     // verify credentials
     let hmac_key = crypt::calculate_sha512(&[&header.master_seed, &transformed_key, b"\x01"])?;
-    let header_hmac_key = hmac_block_stream::get_hmac_block_key(usize::max_value(), &hmac_key)?;
+    let header_hmac_key = hmac_block_stream::get_hmac_block_key(u64::max_value(), &hmac_key)?;
     if header_hmac != crypt::calculate_hmac(&[header_data], &header_hmac_key)?.as_slice() {
         return Err(Error::IncorrectKey);
     }

--- a/src/result.rs
+++ b/src/result.rs
@@ -27,7 +27,7 @@ pub enum DatabaseIntegrityError {
     },
     HeaderHashMismatch,
     BlockHashMismatch {
-        block_index: usize,
+        block_index: u64,
     },
     InvalidKDBXIdentifier,
     InvalidKDBXVersion {


### PR DESCRIPTION
This fixes #41 
Calculations were using `usize` and the values are >2^32 (apparently) -- a simple replace with u64 seems to work.
Added 1 test to CI on arm32 as it is _very_ slow right now. (I am investigating why)