### PR TITLE
Updated dependecies and fixed issues related to them.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,23 +10,14 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "aes"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -37,9 +28,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "atty"
@@ -60,12 +51,6 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "base64"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -78,9 +63,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -89,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
@@ -102,8 +87,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
 dependencies = [
- "block-padding",
- "cipher",
+ "block-padding 0.2.1",
+ "cipher 0.3.0",
 ]
 
 [[package]]
@@ -113,10 +98,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "block-padding"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.3",
+]
 
 [[package]]
 name = "cfg-if"
@@ -132,12 +135,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8756167ea0aca10e066cdbe7813bd71d2f24e69b0bc7b50509590cef2ce0b9"
+checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher",
+ "cipher 0.4.3",
  "cpufeatures",
 ]
 
@@ -164,18 +167,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "2.33.3"
+name = "cipher"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
- "ansi_term",
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+dependencies = [
  "atty",
  "bitflags",
+ "indexmap",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -186,9 +199,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -204,32 +217,33 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
+name = "crypto-common"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "generic-array",
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -255,6 +269,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,25 +291,51 @@ checksum = "21e4590e13640f19f249fe3e4eca5113bc4289f2497710378190e7f4bd96f45b"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
  "digest",
 ]
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding 0.3.2",
+ "generic-array",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "keepass"
 version = "0.4.10"
 dependencies = [
  "aes",
- "base64 0.13.0",
+ "base64",
  "block-modes",
  "byteorder",
+ "cbc",
  "chacha20",
  "chrono",
- "cipher",
+ "cipher 0.4.3",
  "clap",
  "flate2",
  "hex-literal",
@@ -314,6 +360,12 @@ name = "libc"
 version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniz_oxide"
@@ -350,63 +402,127 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "rpassword"
-version = "5.0.1"
+name = "os_str_bytes"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rpassword"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
 dependencies = [
  "libc",
+ "serde",
+ "serde_json",
  "winapi",
 ]
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+checksum = "b50162d19404029c1ceca6f6980fe40d45c8b369f6f44446fa14bb39573b5bb9"
 dependencies = [
- "base64 0.12.1",
+ "base64",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
 ]
 
 [[package]]
-name = "salsa20"
-version = "0.8.1"
+name = "ryu"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.3",
 ]
 
 [[package]]
 name = "secstr"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce2c726741c320e5b8f1edd9a21b3c2c292ae94514afd001d41d81ba143dafc"
+checksum = "49fa8c1d89e7dc5e2776fbf507d8b088ff61bbaf83bf4da1cc9ed1c061358104"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "sha2"
-version = "0.9.5"
+name = "serde"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
- "block-buffer",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
- "opaque-debug",
 ]
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -415,13 +531,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "syn"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
- "unicode-width",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "time"
@@ -436,32 +569,24 @@ dependencies = [
 
 [[package]]
 name = "twofish"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728f6b7e784825d272fe9d2a77e44063f4197a570cbedc6fdcc90a6ddac91296"
+checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
 dependencies = [
- "byteorder",
- "cipher",
- "opaque-debug",
+ "cipher 0.4.3",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
+name = "unicode-xid"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "version_check"
@@ -490,6 +615,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,24 +21,25 @@ default = []
 [dependencies]
 byteorder = "1"
 flate2 = "1"
-secstr = "0.4"
+secstr = "0.5"
 xml-rs = "0.8"
 base64 = "0.13"
 hex-literal = "0.3"
-rust-argon2 = "0.8"
-sha2 = "0.9"
-aes = "0.7"
-block-modes = "0.8"
-hmac = "0.11"
-salsa20 = "0.8"
-chacha20 = "0.7"
-cipher = "0.3"
-twofish = "0.6"
+rust-argon2 = "1.0.0"
+sha2 = "0.10.2"
+aes = "0.7.5"
+block-modes = "0.8.1"
+hmac = "0.12.1"
+salsa20 = "0.10.2"
+chacha20 = "0.9.0"
+cipher = "0.4.3"
+twofish = "0.7.1"
+cbc = "0.1.2"
 chrono = "0.4"
 
 # dependencies for command-line utilities
-clap = { version = "2.33.0", optional = true }
-rpassword = { version = "5.0.1", optional = true }
+clap = { version = "3.1.8", optional = true }
+rpassword = { version = "6.0.1", optional = true }
 
 [[bin]]
 name = "kp-dump-xml"

--- a/src/bin/kp-show-db.rs
+++ b/src/bin/kp-show-db.rs
@@ -32,8 +32,8 @@ pub fn main() -> Result<()> {
 
     let mut keyfile: Option<File> = args.value_of("keyfile").and_then(|f| File::open(f).ok());
 
-    let password = rpassword::read_password_from_tty(Some("Password (or blank for none): "))
-        .expect("Read password");
+    let password = rpassword::prompt_password("Password (or blank for none): ")
+        .expect("Could not read password from TTY");
 
     let password = if password.is_empty() {
         None

--- a/src/crypt/ciphers.rs
+++ b/src/crypt/ciphers.rs
@@ -3,7 +3,10 @@ use crate::result::{CryptoError, DatabaseIntegrityError, Error, Result};
 use aes::Aes256;
 use block_modes::{block_padding::Pkcs7, BlockMode, Cbc as block_modes_cbc};
 use cipher::{generic_array::GenericArray, BlockDecryptMut};
-use salsa20::{cipher::{KeyIvInit, StreamCipher}, Salsa20};
+use salsa20::{
+    cipher::{KeyIvInit, StreamCipher},
+    Salsa20,
+};
 
 pub(crate) trait Cipher {
     fn decrypt(&mut self, ciphertext: &[u8]) -> Result<Vec<u8>>;

--- a/src/crypt/mod.rs
+++ b/src/crypt/mod.rs
@@ -4,7 +4,7 @@ use cipher::generic_array::{
     GenericArray,
 };
 
-use hmac::{Hmac, Mac, NewMac};
+use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256, Sha512};
 
 pub(crate) mod ciphers;

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,18 +5,18 @@ pub enum CryptoError {
     Argon2 {
         e: argon2::Error,
     },
-    InvalidKeyLength {
-        e: hmac::crypto_mac::InvalidKeyLength,
-    },
     InvalidKeyIvLength {
         e: block_modes::InvalidKeyIvLength,
     },
-    InvalidKeyNonceLength {
-        e: cipher::errors::InvalidLength,
+    InvalidLength {
+        e: cipher::InvalidLength,
     },
     BlockMode {
         e: block_modes::BlockModeError,
     },
+    InvalidPadding {
+        e: cipher::block_padding::UnpadError
+    }
 }
 
 #[derive(Debug)]
@@ -265,11 +265,9 @@ impl std::fmt::Display for CryptoError {
             match self {
                 CryptoError::Argon2 { e } => format!("Problem deriving key with Argon2: {}", e),
                 CryptoError::InvalidKeyIvLength { e } => format!("Invalid key / IV length: {}", e),
-                CryptoError::InvalidKeyLength { e } => format!("Invalid key length: {}", e),
-                CryptoError::InvalidKeyNonceLength { e } => {
-                    format!("Invalid key / nonce length: {}", e)
-                }
+                CryptoError::InvalidLength { e } => format!("Invalid input length: {}", e),
                 CryptoError::BlockMode { e } => format!("Block mode error: {}", e),
+                CryptoError::InvalidPadding { e } => format!("Padding error: {}", e)
             }
         )
     }
@@ -281,9 +279,9 @@ impl std::error::Error for CryptoError {
         match self {
             CryptoError::Argon2 { e } => Some(e),
             CryptoError::InvalidKeyIvLength { e } => Some(e),
-            CryptoError::InvalidKeyNonceLength { .. } => None, // TODO pass this through once e implements Error
-            CryptoError::InvalidKeyLength { .. } => None, // TODO pass this through once e implements Error
+            CryptoError::InvalidLength { .. } => None, // TODO pass this through once e implements Error
             CryptoError::BlockMode { e } => Some(e),
+            CryptoError::InvalidPadding { .. } => None
         }
     }
 }
@@ -340,19 +338,20 @@ impl From<argon2::Error> for CryptoError {
     }
 }
 
-impl From<hmac::crypto_mac::InvalidKeyLength> for CryptoError {
+impl From<cipher::InvalidLength> for CryptoError {
     #[cfg_attr(tarpaulin, skip)]
-    fn from(e: hmac::crypto_mac::InvalidKeyLength) -> Self {
-        CryptoError::InvalidKeyLength { e }
+    fn from(e: cipher::InvalidLength) -> Self {
+        CryptoError::InvalidLength { e }
     }
 }
 
-impl From<cipher::errors::InvalidLength> for CryptoError {
+impl From<cipher::block_padding::UnpadError> for CryptoError {
     #[cfg_attr(tarpaulin, skip)]
-    fn from(e: cipher::errors::InvalidLength) -> Self {
-        CryptoError::InvalidKeyNonceLength { e }
+    fn from(e: cipher::block_padding::UnpadError) -> Self {
+        CryptoError::InvalidPadding { e }
     }
 }
+
 
 impl From<block_modes::InvalidKeyIvLength> for CryptoError {
     #[cfg_attr(tarpaulin, skip)]

--- a/src/result.rs
+++ b/src/result.rs
@@ -15,8 +15,8 @@ pub enum CryptoError {
         e: block_modes::BlockModeError,
     },
     InvalidPadding {
-        e: cipher::block_padding::UnpadError
-    }
+        e: cipher::block_padding::UnpadError,
+    },
 }
 
 #[derive(Debug)]
@@ -267,7 +267,7 @@ impl std::fmt::Display for CryptoError {
                 CryptoError::InvalidKeyIvLength { e } => format!("Invalid key / IV length: {}", e),
                 CryptoError::InvalidLength { e } => format!("Invalid input length: {}", e),
                 CryptoError::BlockMode { e } => format!("Block mode error: {}", e),
-                CryptoError::InvalidPadding { e } => format!("Padding error: {}", e)
+                CryptoError::InvalidPadding { e } => format!("Padding error: {}", e),
             }
         )
     }
@@ -281,7 +281,7 @@ impl std::error::Error for CryptoError {
             CryptoError::InvalidKeyIvLength { e } => Some(e),
             CryptoError::InvalidLength { .. } => None, // TODO pass this through once e implements Error
             CryptoError::BlockMode { e } => Some(e),
-            CryptoError::InvalidPadding { .. } => None
+            CryptoError::InvalidPadding { .. } => None,
         }
     }
 }
@@ -351,7 +351,6 @@ impl From<cipher::block_padding::UnpadError> for CryptoError {
         CryptoError::InvalidPadding { e }
     }
 }
-
 
 impl From<block_modes::InvalidKeyIvLength> for CryptoError {
     #[cfg_attr(tarpaulin, skip)]


### PR DESCRIPTION
Could not update the AES dependency as it is affected by the deprecation of block-cipher, no easy replacement for ECB mode required for KDBX versions <4. Could have hacked it with a manual version but decided it was better to get the others up and running with the latest versions (which should bring some performance benefits on some platforms).

Results was changed due to unification of some results value upstream. Seems that there is less differentiation now on the key lengths etc. There is now a padding error that is returned, but should be careful about how that's exposed, as that way leads to oracle attacks if you're not careful. Not necessarily an issue for libraries but something to be born in mind for anything that uses this and returns data to users.