### PR TITLE
feat: parse group and entry uuids

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -135,6 +135,9 @@ impl Database {
 /// A database group with child groups and entries
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct Group {
+    /// The unique identifier of the group
+    pub uuid: String,
+
     /// The name of the group
     pub name: String,
 
@@ -321,6 +324,7 @@ impl<'a> std::convert::From<&'a mut Node> for NodeRefMut<'a> {
 /// A database entry containing several key-value fields.
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct Entry {
+    pub uuid: String,
     pub fields: HashMap<String, Value>,
     pub autotype: Option<AutoType>,
     pub expires: bool,
@@ -346,6 +350,10 @@ impl<'a> Entry {
             Some(&Value::Unprotected(_)) => None,
             None => None,
         }
+    }
+
+    pub fn get_uuid(&'a self) -> &'a str {
+        &self.uuid
     }
 
     /// Get a timestamp field by name

--- a/src/parse/kdb.rs
+++ b/src/parse/kdb.rs
@@ -292,6 +292,7 @@ fn parse_entries(
 
 fn parse_db(header: &KDBHeader, data: &[u8]) -> Result<Group> {
     let mut root = Group {
+        uuid: Default::default(),
         name: "Root".to_owned(),
         children: Default::default(),
         expires: Default::default(),

--- a/src/parse/kdbx3.rs
+++ b/src/parse/kdbx3.rs
@@ -172,6 +172,7 @@ pub(crate) fn parse(data: &[u8], key_elements: &[Vec<u8>]) -> Result<Database> {
     let mut inner_decryptor = header.inner_cipher.get_cipher(&stream_key)?;
 
     let mut root = Group {
+        uuid: Default::default(),
         name: "Root".to_owned(),
         children: Default::default(),
         expires: Default::default(),

--- a/tests/entry_tests.rs
+++ b/tests/entry_tests.rs
@@ -9,6 +9,7 @@ mod tests {
 
         // get an entry on the root node
         if let Some(NodeRef::Entry(e)) = db.root.get(&["Sample Entry"]) {
+            assert_eq!(e.get_uuid(), "Dr7dsu1OUUS8NBowkmalEw==");
             assert_eq!(e.get_title(), Some("Sample Entry"));
             assert_eq!(e.get_username(), Some("User Name"));
             assert_eq!(e.get_password(), Some("Password"));
@@ -34,6 +35,7 @@ mod tests {
         }
 
         if let Some(NodeRef::Entry(e)) = db.root.get(&["General", "Subgroup", "test entry"]) {
+            assert_eq!(e.get_uuid(), "XkyK0ZzVOUyQORF43BQLSg==");
             assert_eq!(e.get_title(), Some("test entry"));
             assert_eq!(e.get_username(), Some("jdoe"));
             assert_eq!(e.get_password(), Some("nWuu5AtqsxqNhnYgLwoB"));
@@ -58,6 +60,7 @@ mod tests {
 
         // get an entry on the root node
         if let Some(NodeRef::Entry(e)) = db.root.get(&["ASDF"]) {
+            assert_eq!(e.get_uuid(), "TzgWvYMwSGWHn6EIoS8oXA==");
             assert_eq!(e.get_title(), Some("ASDF"));
             assert_eq!(e.get_username(), Some("ghj"));
             assert_eq!(e.get_password(), Some("klmno"));


### PR DESCRIPTION
This PR implements UUID parsing for both entries and groups. Some of the code overlaps with [DavidVentura:recycle-uuid](https://github.com/sseemayer/keepass-rs/pull/43), but I tried to keep the implementations similar to minimize potential conflicts.

@sseemayer thanks for reviewing :eyes: 