### PR TITLE
docs: use readme for create doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
 ## Installation
 Add the following to the `dependencies` section of your `Cargo.toml`:
 
-```
+```ignore
 [dependencies]
 keepass = "*"
 ```
@@ -69,7 +69,7 @@ This library contains an optionally-compiled command line application to dump ou
 
 Since the tool depends on additional crates, it is not compiled until you specify the `utilities` feature, e.g.
 
-```
+```ignore
 cargo run --release --features "utilities" --bin kp-dump-xml -- path/to/database.kdbx
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,36 +1,4 @@
-//! keepass: KeePass .kdbx database file parser for Rust
-//!
-//!
-//! ```
-//! extern crate keepass;
-//!
-//! use keepass::{Database, NodeRef, Result, Error};
-//! use std::fs::File;
-//!
-//! fn main() -> Result<()> {
-//!     // Open KeePass database
-//!     let path = std::path::Path::new("tests/resources/test_db_with_password.kdbx");
-//!     let db = Database::open(&mut File::open(path)?, Some("demopass"), None)?;
-//!
-//!     // Iterate over all Groups and Nodes
-//!     for node in &db.root {
-//!         match node {
-//!             NodeRef::Group(g) => {
-//!                 println!("Saw group '{0}'", g.name);
-//!             },
-//!             NodeRef::Entry(e) => {
-//!                 let title = e.get_title().unwrap();
-//!                 let user = e.get_username().unwrap();
-//!                 let pass = e.get_password().unwrap();
-//!                 println!("Entry '{0}': '{1}' : '{2}'", title, user, pass);
-//!             }
-//!         }
-//!     }
-//!
-//!     Ok(())
-//! }
-//! ```
-
+#![doc = include_str!("../README.md")]
 #![recursion_limit = "1024"]
 
 mod config;


### PR DESCRIPTION
This will populate the crate documentation page with everything in the README. It also avoids duplicating the same example in two places, and makes sure that the examples in the README are tested.

@sseemayer thanks for the review :pray: 