### PR TITLE
ci: isolate the armv7 regression test 

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -39,5 +39,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: install armv7 target
+        run: rustup target add armv7-unknown-linux-musleabihf
       - name: run cargo test
         run: cargo test --release --target armv7-unknown-linux-musleabihf tests::kdbx4_entry

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -7,29 +7,37 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - name: run cargo check
+        run: cargo check
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: run cargo test
+        run: cargo test
+
+  armv7-test:
+    name: ARMv7 Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
         with:
-          command: test
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test --release --target armv7-unknown-linux-musleabihf tests::kdbx4_entry
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: run cargo test
+        run: cargo test --release --target armv7-unknown-linux-musleabihf tests::kdbx4_entry

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -41,5 +41,8 @@ jobs:
           override: true
       - name: install armv7 target
         run: rustup target add armv7-unknown-linux-musleabihf
-      - name: run cargo test
-        run: cargo test --release --target armv7-unknown-linux-musleabihf tests::kdbx4_entry
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --release --target armv7-unknown-linux-musleabihf tests::kdbx4_entry


### PR DESCRIPTION
This moves the armv7 regression test to a separate job, so that failures in the regression tests are not confused with failures when running all the unit tests. The armv7 regression test was added today in https://github.com/sseemayer/keepass-rs/pull/45, and has been failing since. I tried fixing the test but was not able to so far, so I think splitting the test is a good compromise for now, so that we can rely on the unit tests again.
cc @DavidVentura 

I also removed reference to the `action-rs/cargo` action, because the rust toolchain is already installed by the `action-rs/toolchain` action. It's even recommended to do so by the action authors: https://github.com/actions-rs/cargo#use-cases
