### PR TITLE
ci: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sseemayer @louib


### PR DESCRIPTION
@sseemayer adding us both as codeowners so we get assigned as reviewers automatically.
@varjolintu feel free to add yourself as code owner if you want to get assigned for reviews as well.
In the future, we could have more granular review assignments, but for now I feel like this makes sense.