### PR TITLE
chore: avoid vulnerable chrono version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ base64 = "0.20"
 hex-literal = "0.3"
 
 secstr = "0.5"
-chrono = "0.4"
+chrono = "0.4.23"
 
 # cryptography
 rust-argon2 = "1.0"


### PR DESCRIPTION
This will make sure we avoid using the vulnerability described [here](https://rustsec.org/advisories/RUSTSEC-2020-0159.html)
The locked version is already 0.4.23, but consuming projects do not use the `Cargo.lock`