### PR TITLE
ci: do not run tests on every push

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 name: Continuous Integration
 


### PR DESCRIPTION
This will make sure that we don't run all the steps twice when working directly from the repo and not from a fork.