### PR TITLE
refactor: extract consts from variant dict parsing

### DIFF
--- a/src/variant_dictionary.rs
+++ b/src/variant_dictionary.rs
@@ -2,6 +2,14 @@ use byteorder::{ByteOrder, LittleEndian};
 use std::collections::HashMap;
 use thiserror::Error;
 
+pub const U32_TYPE_ID: u8 = 0x04;
+pub const U64_TYPE_ID: u8 = 0x05;
+pub const BOOL_TYPE_ID: u8 = 0x08;
+pub const I32_TYPE_ID: u8 = 0x0c;
+pub const I64_TYPE_ID: u8 = 0x0d;
+pub const STR_TYPE_ID: u8 = 0x18;
+pub const BYTES_TYPE_ID: u8 = 0x42;
+
 #[derive(Debug)]
 pub(crate) struct VariantDictionary {
     data: HashMap<String, VariantDictionaryValue>,
@@ -50,15 +58,15 @@ impl VariantDictionary {
             pos += value_length;
 
             let value = match value_type {
-                0x04 => VariantDictionaryValue::UInt32(LittleEndian::read_u32(value_buffer)),
-                0x05 => VariantDictionaryValue::UInt64(LittleEndian::read_u64(value_buffer)),
-                0x08 => VariantDictionaryValue::Bool(value_buffer != [0]),
-                0x0c => VariantDictionaryValue::Int32(LittleEndian::read_i32(value_buffer)),
-                0x0d => VariantDictionaryValue::Int64(LittleEndian::read_i64(value_buffer)),
-                0x18 => VariantDictionaryValue::String(
+                U32_TYPE_ID => VariantDictionaryValue::UInt32(LittleEndian::read_u32(value_buffer)),
+                U64_TYPE_ID => VariantDictionaryValue::UInt64(LittleEndian::read_u64(value_buffer)),
+                BOOL_TYPE_ID => VariantDictionaryValue::Bool(value_buffer != [0]),
+                I32_TYPE_ID => VariantDictionaryValue::Int32(LittleEndian::read_i32(value_buffer)),
+                I64_TYPE_ID => VariantDictionaryValue::Int64(LittleEndian::read_i64(value_buffer)),
+                STR_TYPE_ID => VariantDictionaryValue::String(
                     String::from_utf8_lossy(value_buffer).to_string(),
                 ),
-                0x42 => VariantDictionaryValue::ByteArray(value_buffer.to_vec()),
+                BYTES_TYPE_ID => VariantDictionaryValue::ByteArray(value_buffer.to_vec()),
                 _ => {
                     return Err(VariantDictionaryError::InvalidValueType { value_type });
                 }


### PR DESCRIPTION
Those same constants will be used when writing databases.