### PR TITLE
chore: bump base64 to latest minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1"
 byteorder = "1"
 flate2 = "1"
 xml-rs = "0.8"
-base64 = "0.20"
+base64 = "0.21"
 hex-literal = "0.3"
 
 secstr = "0.5"

--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -1,4 +1,5 @@
 use crate::crypt::{calculate_sha256, CryptographyError};
+use base64::{engine::general_purpose as base64_engine, Engine as _};
 use thiserror::Error;
 use xml::name::OwnedName;
 use xml::reader::{EventReader, XmlEvent};
@@ -40,7 +41,7 @@ fn parse_xml_keyfile(xml: &[u8]) -> Result<Vec<u8>, KeyfileError> {
                     let key_base64 = s.as_bytes().to_vec();
 
                     // Check if the key is base64-encoded. If yes, return decoded bytes
-                    return if let Ok(key) = ::base64::decode(&key_base64) {
+                    return if let Ok(key) = base64_engine::STANDARD.decode(&key_base64) {
                         Ok(key)
                     } else {
                         Ok(key_base64)

--- a/src/xml_parse.rs
+++ b/src/xml_parse.rs
@@ -1,7 +1,7 @@
 use crate::crypt::{ciphers::Cipher, CryptographyError};
 
+use base64::{engine::general_purpose as base64_engine, Engine as _};
 use secstr::SecStr;
-
 use thiserror::Error;
 use xml::name::OwnedName;
 use xml::reader::{EventReader, XmlEvent};
@@ -30,7 +30,7 @@ fn parse_xml_timestamp(t: &str) -> Result<chrono::NaiveDateTime, XmlParseError> 
         // In KDBX4, timestamps are stored as seconds, Base64 encoded, since 0001-01-01 00:00:00
         // So, if we don't have a valid ISO 8601 string, assume we have found a Base64 encoded int.
         _ => {
-            let v = base64::decode(t)?;
+            let v = base64_engine::STANDARD.decode(t)?;
 
             // Cast the Vec created by base64::decode into the array expected by i64::from_le_bytes
             let mut a: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
@@ -314,7 +314,7 @@ pub(crate) fn parse_xml_block(
                                 // Use the decryptor to decrypt the protected
                                 // and base64-encoded value
                                 //
-                                let buf = base64::decode(&c)?;
+                                let buf = base64_engine::STANDARD.decode(&c)?;
 
                                 let buf_decode = inner_cipher.decrypt(&buf)?;
 


### PR DESCRIPTION
New version was published today, Some functions were marked as deprecated, so this PR will migrate to the newer form.
[Release notes are here](https://github.com/marshallpierce/rust-base64/commit/b59e4ea530bbcd030e0ddbda9cefc0ba8983a4f5)