### PR TITLE
ci: migrate code coverage to gha

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+      - master
+
+name: Merge on Master
+
+jobs:
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:develop-nightly
+      options: --security-opt seccomp=unconfined
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate code coverage
+        run: |
+          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+      - uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: false
+          verbose: true


### PR DESCRIPTION
This PR migrates the code coverage CI job from Travis to GitHub Actions. The code is based on [the tarpaulin documentation](https://github.com/xd009642/tarpaulin/tree/master/#github-actions). Since this is a public repository, we don't need to provide a token to codecov for the upload to work (see https://github.com/codecov/codecov-action#usage)

The workflow will only be triggered when merging to master.