### PR TITLE
docs: update build status badge to gha

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/keepass.svg)](https://crates.io/crates/keepass)
 [![Documentation](https://docs.rs/keepass/badge.svg)](https://docs.rs/keepass/)
-[![Build Status](https://travis-ci.org/sseemayer/keepass-rs.svg?branch=master)](https://travis-ci.org/sseemayer/keepass-rs)
+[![Build Status](https://github.com/sseemayer/keepass-rs/actions/workflows/rust-ci.yml/badge.svg?branch=master)](https://github.com/sseemayer/keepass-rs/actions/workflows/rust-ci.yml)
 [![codecov](https://codecov.io/gh/sseemayer/keepass-rs/branch/master/graph/badge.svg)](https://codecov.io/gh/sseemayer/keepass-rs)
 [![dependency status](https://deps.rs/repo/github/sseemayer/keepass-rs/status.svg)](https://deps.rs/repo/github/sseemayer/keepass-rs)
 [![License file](https://img.shields.io/github/license/sseemayer/keepass-rs)](https://github.com/sseemayer/keepass-rs/blob/master/LICENSE)


### PR DESCRIPTION
The build status badge was still redirecting to travis-ci, with the last build being 3 years old.