### PR TITLE
fix: pin the tarpaulin image and use stable rust

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,13 +10,13 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:develop-nightly
+      image: xd009642/tarpaulin:0.21.0
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v3
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
       - uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
The current coverage workflow is failing with the latest tarpaulin image, as seen [here](https://github.com/sseemayer/keepass-rs/actions/runs/3912616535/jobs/6687480974).
This PR switches to the latest stable release instead. I tested locally, and I was able to generate the coverage report.

I think we'll also have to update the coverage badge in the README. The current codecov project page displays the following error message:
```
 This repo has been deactivated 
```
 