### PR TITLE
ci: use acronym for ci job

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -4,7 +4,7 @@ on:
       - master
   pull_request:
 
-name: Continuous Integration
+name: CI
 
 jobs:
   check:


### PR DESCRIPTION
The long form takes a lot of place in the README, so I suggest we use this well-known acronym instead.