### PR TITLE
refactor: rename database creation fn

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -390,7 +390,7 @@ impl Database {
         Ok(data)
     }
 
-    pub fn create_database(
+    pub fn new(
         outer_cipher_suite: OuterCipherSuite,
         compression: Compression,
         inner_cipher_suite: InnerCipherSuite,

--- a/src/parse/kdbx4.rs
+++ b/src/parse/kdbx4.rs
@@ -476,7 +476,7 @@ mod kdbx4_tests {
         root_group.children.push(Node::Entry(Entry::new()));
         root_group.children.push(Node::Entry(Entry::new()));
         root_group.children.push(Node::Entry(Entry::new()));
-        let db = Database::create_database(
+        let db = Database::new(
             outer_cipher_suite,
             compression,
             inner_cipher_suite,
@@ -681,7 +681,7 @@ mod kdbx4_tests {
     pub fn binary_attachments() {
         let mut root_group = Group::new("Root");
         root_group.children.push(Node::Entry(Entry::new()));
-        let db = Database::create_database(
+        let db = Database::new(
             OuterCipherSuite::AES256,
             Compression::GZip,
             InnerCipherSuite::Salsa20,

--- a/src/xml_parse.rs
+++ b/src/xml_parse.rs
@@ -557,7 +557,7 @@ mod xml_tests {
 
         root_group.children.push(Node::Entry(entry));
 
-        let db = Database::create_database(
+        let db = Database::new(
             OuterCipherSuite::AES256,
             Compression::GZip,
             InnerCipherSuite::Salsa20,
@@ -616,7 +616,7 @@ mod xml_tests {
 
         root_group.children.push(Node::Entry(entry));
 
-        let db = Database::create_database(
+        let db = Database::new(
             OuterCipherSuite::AES256,
             Compression::GZip,
             InnerCipherSuite::Salsa20,


### PR DESCRIPTION
`_database` is redundant in that case, and `::new` is already the name used by the `Group` and `Entry` structs.