### PR TITLE
feat: use argon2 kdf settings

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -415,22 +415,28 @@ impl Database {
         master_seed.resize(crate::parse::kdbx4::HEADER_MASTER_SEED_SIZE.into(), 0);
         getrandom::getrandom(&mut master_seed)?;
 
+        // FIXME obviously this is ugly. We should be able to change
+        // the seed without destructuring all the kdf enum types.
         match kdf_setting {
             KdfSettings::Aes { rounds, .. } => {
-                // FIXME obviously this is ugly. We should be able to change
-                // the seed in the first kdf object.
                 kdf = KdfSettings::Aes {
                     seed: kdf_seed,
                     rounds,
                 };
             }
-            KdfSettings::Argon2 { .. } => {
+            KdfSettings::Argon2 {
+                iterations,
+                memory,
+                parallelism,
+                version,
+                ..
+            } => {
                 kdf = KdfSettings::Argon2 {
                     salt: kdf_seed,
-                    iterations: 100,
-                    memory: 1000000,
-                    parallelism: 1,
-                    version: argon2::Version::Version13,
+                    iterations,
+                    memory,
+                    parallelism,
+                    version,
                 };
             }
         };

--- a/src/parse/kdbx4.rs
+++ b/src/parse/kdbx4.rs
@@ -525,7 +525,7 @@ mod kdbx4_tests {
             KdfSettings::Argon2 {
                 salt: vec![],
                 iterations: 1000,
-                memory: 134217728,
+                memory: 65536,
                 parallelism: 8,
                 version: argon2::Version::Version13,
             },
@@ -541,7 +541,7 @@ mod kdbx4_tests {
             KdfSettings::Argon2 {
                 salt: vec![],
                 iterations: 1000,
-                memory: 134217728,
+                memory: 65536,
                 parallelism: 8,
                 version: argon2::Version::Version13,
             },
@@ -569,8 +569,8 @@ mod kdbx4_tests {
             InnerCipherSuite::Salsa20,
             KdfSettings::Argon2 {
                 salt: vec![],
-                iterations: 1000,
-                memory: 1000,
+                iterations: 100,
+                memory: 65536,
                 parallelism: 1,
                 version: argon2::Version::Version13,
             },
@@ -612,7 +612,7 @@ mod kdbx4_tests {
             KdfSettings::Argon2 {
                 salt: vec![],
                 iterations: 1000,
-                memory: 134217728,
+                memory: 65536,
                 parallelism: 8,
                 version: argon2::Version::Version13,
             },
@@ -628,7 +628,7 @@ mod kdbx4_tests {
             KdfSettings::Argon2 {
                 salt: vec![],
                 iterations: 1000,
-                memory: 134217728,
+                memory: 65536,
                 parallelism: 8,
                 version: argon2::Version::Version13,
             },
@@ -670,7 +670,7 @@ mod kdbx4_tests {
             KdfSettings::Argon2 {
                 salt: vec![],
                 iterations: 1000,
-                memory: 134217728,
+                memory: 65536,
                 parallelism: 8,
                 version: argon2::Version::Version13,
             },
@@ -688,7 +688,7 @@ mod kdbx4_tests {
             KdfSettings::Argon2 {
                 salt: vec![],
                 iterations: 1000,
-                memory: 1000,
+                memory: 65536,
                 parallelism: 1,
                 version: argon2::Version::Version13,
             },

--- a/src/xml_parse.rs
+++ b/src/xml_parse.rs
@@ -564,7 +564,7 @@ mod xml_tests {
             KdfSettings::Argon2 {
                 salt: vec![],
                 iterations: 1000,
-                memory: 1000,
+                memory: 65536,
                 parallelism: 1,
                 version: argon2::Version::Version13,
             },
@@ -623,7 +623,7 @@ mod xml_tests {
             KdfSettings::Argon2 {
                 salt: vec![],
                 iterations: 1000,
-                memory: 1000,
+                memory: 65536,
                 parallelism: 1,
                 version: argon2::Version::Version13,
             },


### PR DESCRIPTION
When I modified the database creation function to actually use the argon2 settings, I started seeing the following test errors:
```
thread 'xml_parse::xml_tests::test_entry' has overflowed its stack
```

Looks like there's a minimum memory required to derive the hashed password with argon2. I'm wondering if we should provide a default value, and a minimum value, to make sure that the value is large enough. I didn't see any recommendations on the crate's documentation. 