### PR TITLE
fix: Prevent stack overflow due to circular type conversions of nested error types

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -63,6 +63,9 @@ pub enum DatabaseKeyError {
     IncorrectKey,
 
     #[error(transparent)]
+    Cryptography(#[from] CryptographyError),
+
+    #[error(transparent)]
     Keyfile(#[from] KeyfileError),
 }
 
@@ -70,6 +73,9 @@ pub enum DatabaseKeyError {
 pub enum DatabaseOpenError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Key(#[from] DatabaseKeyError),
 
     #[error(transparent)]
     DatabaseIntegrity(#[from] DatabaseIntegrityError),
@@ -191,89 +197,59 @@ pub enum DatabaseSaveError {
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
-}
 
-impl From<DatabaseKeyError> for DatabaseOpenError {
-    fn from(value: DatabaseKeyError) -> Self {
-        value.into()
-    }
-}
+    #[error(transparent)]
+    Key(#[from] DatabaseKeyError),
 
-impl From<DatabaseKeyError> for DatabaseSaveError {
-    fn from(value: DatabaseKeyError) -> Self {
-        value.into()
-    }
-}
-
-impl From<CryptographyError> for DatabaseKeyError {
-    fn from(value: CryptographyError) -> Self {
-        value.into()
-    }
-}
-
-impl From<CryptographyError> for DatabaseSaveError {
-    fn from(value: CryptographyError) -> Self {
-        value.into()
-    }
+    #[error(transparent)]
+    Cryptography(#[from] CryptographyError),
 }
 
 impl From<CryptographyError> for DatabaseOpenError {
-    fn from(value: CryptographyError) -> Self {
-        value.into()
+    fn from(e: CryptographyError) -> Self {
+        DatabaseIntegrityError::from(e).into()
     }
 }
 
 impl From<BlockStreamError> for DatabaseOpenError {
-    fn from(value: BlockStreamError) -> Self {
-        value.into()
-    }
-}
-
-impl From<BlockStreamError> for DatabaseSaveError {
-    fn from(value: BlockStreamError) -> Self {
-        value.into()
+    fn from(e: BlockStreamError) -> Self {
+        DatabaseIntegrityError::from(e).into()
     }
 }
 
 impl From<XmlParseError> for DatabaseOpenError {
-    fn from(value: XmlParseError) -> Self {
-        value.into()
-    }
-}
-
-impl From<OuterCipherSuiteError> for DatabaseOpenError {
-    fn from(value: OuterCipherSuiteError) -> Self {
-        value.into()
+    fn from(e: XmlParseError) -> Self {
+        DatabaseIntegrityError::from(e).into()
     }
 }
 
 impl From<InnerCipherSuiteError> for DatabaseOpenError {
-    fn from(value: InnerCipherSuiteError) -> Self {
-        value.into()
+    fn from(e: InnerCipherSuiteError) -> Self {
+        DatabaseIntegrityError::from(e).into()
+    }
+}
+
+impl From<OuterCipherSuiteError> for DatabaseOpenError {
+    fn from(e: OuterCipherSuiteError) -> Self {
+        DatabaseIntegrityError::from(e).into()
     }
 }
 
 impl From<KdfSettingsError> for DatabaseOpenError {
-    fn from(value: KdfSettingsError) -> Self {
-        value.into()
+    fn from(e: KdfSettingsError) -> Self {
+        DatabaseIntegrityError::from(e).into()
     }
 }
 
 impl From<VariantDictionaryError> for DatabaseOpenError {
-    fn from(value: VariantDictionaryError) -> Self {
-        value.into()
-    }
-}
-
-impl From<VariantDictionaryError> for DatabaseSaveError {
-    fn from(value: VariantDictionaryError) -> Self {
-        value.into()
+    fn from(e: VariantDictionaryError) -> Self {
+        DatabaseIntegrityError::from(e).into()
     }
 }
 
 impl From<CompressionError> for DatabaseOpenError {
-    fn from(value: CompressionError) -> Self {
-        value.into()
+    fn from(e: CompressionError) -> Self {
+        DatabaseIntegrityError::from(e).into()
     }
 }
 

--- a/src/hmac_block_stream.rs
+++ b/src/hmac_block_stream.rs
@@ -61,7 +61,7 @@ pub(crate) fn read_hmac_block_stream(
 pub(crate) fn write_hmac_block_stream(
     data: &[u8],
     key: &GenericArray<u8, U64>,
-) -> Result<Vec<u8>, BlockStreamError> {
+) -> Result<Vec<u8>, CryptographyError> {
     let mut out = Vec::new();
 
     let mut pos = 0;

--- a/src/parse/kdbx4.rs
+++ b/src/parse/kdbx4.rs
@@ -108,7 +108,7 @@ fn dump_outer_header(header: &KDBX4Header) -> Result<Vec<u8>, DatabaseSaveError>
     write_header_field(&mut header_data, HEADER_MASTER_SEED, &header.master_seed);
 
     let vd: VariantDictionary = header.kdf.dump();
-    write_header_field(&mut header_data, HEADER_KDF_PARAMS, &vd.dump()?);
+    write_header_field(&mut header_data, HEADER_KDF_PARAMS, &vd.dump());
 
     write_header_field(&mut header_data, HEADER_END, &[]);
 

--- a/src/variant_dictionary.rs
+++ b/src/variant_dictionary.rs
@@ -78,7 +78,7 @@ impl VariantDictionary {
         Ok(VariantDictionary { data })
     }
 
-    pub(crate) fn dump(&self) -> Result<Vec<u8>, VariantDictionaryError> {
+    pub(crate) fn dump(&self) -> Vec<u8> {
         let mut data: Vec<u8> = vec![];
 
         data.resize(2, 0);
@@ -141,7 +141,7 @@ impl VariantDictionary {
             data.extend_from_slice(&field_buffer);
         }
 
-        Ok(data)
+        data
     }
 
     pub(crate) fn get<T>(&self, key: &str) -> Result<T, VariantDictionaryError>

--- a/tests/entry_tests.rs
+++ b/tests/entry_tests.rs
@@ -82,4 +82,23 @@ mod tests {
 
         Ok(())
     }
+    #[test]
+    fn kdbx4_entry_bad_password() -> Result<(), DatabaseOpenError> {
+        let path = Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
+        let db = Database::open(
+            &mut File::open(path)?,
+            Some("this password is not correct"),
+            None,
+        );
+
+        assert!(db.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn databasekeyerror_into_databaseopenerror() -> Result<(), DatabaseOpenError> {
+        let _: DatabaseOpenError = DatabaseKeyError::IncorrectKey.into();
+        Ok(())
+    }
 }


### PR DESCRIPTION
Hi
Only adding a test because I don't understand what the problem is
When working on the TOTP PR, I noticed that providing a bad password gave:
```
fatal runtime error: stack overflow
```

I've isolated it to this `Error` type conversion, but the `#Error` macro is magic 