### PR TITLE
ci: add a workflow to lint commits

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,11 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5


### PR DESCRIPTION
The default help URL will be [this one](https://github.com/conventional-changelog/commitlint/#what-is-commitlint), but we can change it if we find it not helpful enough. For example, we could redirect to our own `CONTRIBUTING.md` once we have one.
This is required before we can add a workflow that automates the releases after a merge on master.