### PR TITLE
ci: cargo check all feature combinations

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,13 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: taiki-e/install-action@v2
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: run cargo check
-        run: cargo check --features utilities
+          tool: cargo-hack
+      - name: run cargo check on all feature combinations
+        run: cargo hack check --feature-powerset --no-dev-deps
 
   test:
     name: Test Suite

--- a/src/bin/kp-show-otp.rs
+++ b/src/bin/kp-show-otp.rs
@@ -44,7 +44,7 @@ pub fn main() -> Result<()> {
 
     if let Some(NodeRef::Entry(e)) = db.root.get(&[&args.entry]) {
         let totp = e.get_otp().unwrap();
-        println!("Token is {}", totp.current_value());
+        println!("Token is {}", totp.value_now().unwrap().code);
         Ok(())
     } else {
         panic!("Could not find entry with provided name")


### PR DESCRIPTION
This PR updates the `check` CI step to test all combinations of features. This should catch more bugs before they get merged into master, especially as we plan on adding more features to the crate. I also fixed a compilation error that made its way into master.