### PR TITLE
chore(ci): move tarpaulin config to file

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,13 +10,13 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:0.21.0
+      image: xd009642/tarpaulin:0.24.0
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v3
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --all-features --exclude-files src/bin/*.rs --workspace --timeout 120 --out Xml
+          cargo tarpaulin --verbose --timeout 120
       - uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Session.vim
 
 ####=== Coverage ===#####
 cobertura.xml
+tarpaulin-report.html

--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,0 +1,6 @@
+[all]
+all-features = true
+workspace = true
+target-dir = "target/coverage/"
+exclude-files = ["src/bin/*", "target/*"]
+out = ["Xml", "Html"]


### PR DESCRIPTION
To aid local running of coverage reports, create a .tarpaulin.toml file that mimics the settings of the GitHub actions workflow.

Also updates the version of the tarpaulin image in the workflow.