### PR TITLE
feat!: implement remaining XML fields

### DIFF
--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -9,7 +9,7 @@ use crate::db::Times;
 use crate::otp::{TOTPError, TOTP};
 
 /// A database entry containing several key-value fields.
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct Entry {
     pub uuid: String,
@@ -136,7 +136,7 @@ impl serde::Serialize for Value {
 }
 
 /// An AutoType setting associated with an Entry
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct AutoType {
     pub enabled: bool,
@@ -145,7 +145,7 @@ pub struct AutoType {
 }
 
 /// A window association associated with an AutoType setting
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct AutoTypeAssociation {
     pub window: Option<String>,

--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use secstr::SecStr;
 use uuid::Uuid;
 
-use crate::db::Times;
+use crate::{db::Times, CustomData};
 
 #[cfg(feature = "totp")]
 use crate::otp::{TOTPError, TOTP};
@@ -18,15 +18,25 @@ pub struct Entry {
     pub tags: Vec<String>,
 
     pub times: Times,
+
+    pub custom_data: CustomData,
+
+    pub icon_id: Option<usize>,
+    pub custom_icon_uuid: Option<String>,
+
+    pub foreground_color: Option<String>,
+    pub background_color: Option<String>,
+
+    pub override_url: Option<String>,
+    pub quality_check: Option<bool>,
+
+    pub history: History,
 }
 impl Entry {
     pub fn new() -> Entry {
         Entry {
             uuid: Uuid::new_v4().to_string(),
-            fields: HashMap::default(),
-            times: Times::default(),
-            autotype: None,
-            tags: vec![],
+            ..Default::default()
         }
     }
 }
@@ -150,4 +160,10 @@ pub struct AutoType {
 pub struct AutoTypeAssociation {
     pub window: Option<String>,
     pub sequence: Option<String>,
+}
+
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+pub struct History {
+    pub entries: Vec<Entry>,
 }

--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -46,6 +46,9 @@ pub struct Group {
     // TODO: in example XML files, this is "null" - what should the type be?
     pub enable_searching: Option<String>,
 
+    /// UUID for the last top visible entry
+    // TODO figure out what that is supposed to mean. According to the KeePass sourcecode, it has
+    // something to do with restoring selected items when re-opening a database.
     pub last_top_visible_entry: Option<String>,
 }
 

--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -8,7 +8,7 @@ use crate::db::{
 };
 
 /// A database group with child groups and entries
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct Group {
     /// The unique identifier of the group
@@ -17,20 +17,44 @@ pub struct Group {
     /// The name of the group
     pub name: String,
 
+    /// Notes for the group
+    pub notes: Option<String>,
+
+    /// ID of the group's icon
+    pub icon_id: Option<usize>,
+
+    /// UUID for a custom group icon
+    pub custom_icon_uuid: Option<String>,
+
     /// The list of child nodes (Groups or Entries)
     pub children: Vec<Node>,
 
     /// The list of time fields for this group
     pub times: Times,
+
+    /// Whether the group is expanded in the user interface
+    pub is_expanded: bool,
+
+    /// Default autotype sequence
+    pub default_autotype_sequence: Option<String>,
+
+    /// Whether autotype is enabled
+    // TODO: in example XML files, this is "null" - what should the type be?
+    pub enable_autotype: Option<String>,
+
+    /// Whether searching is enabled
+    // TODO: in example XML files, this is "null" - what should the type be?
+    pub enable_searching: Option<String>,
+
+    pub last_top_visible_entry: Option<String>,
 }
 
 impl Group {
     pub fn new(name: &str) -> Group {
         Group {
-            children: vec![],
             name: name.to_string(),
             uuid: Uuid::new_v4().to_string(),
-            times: Times::default(),
+            ..Default::default()
         }
     }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -459,7 +459,7 @@ impl Database {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct Times {
     /// Does this node expire

--- a/src/db/node.rs
+++ b/src/db/node.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use crate::db::{entry::Entry, group::Group};
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub enum Node {
     Group(Group),

--- a/src/parse/kdb.rs
+++ b/src/parse/kdb.rs
@@ -294,10 +294,8 @@ fn parse_entries(
 
 fn parse_db(header: &KDBHeader, data: &[u8]) -> Result<Group, DatabaseIntegrityError> {
     let mut root = Group {
-        uuid: Default::default(),
         name: "Root".to_owned(),
-        children: Default::default(),
-        times: Default::default(),
+        ..Default::default()
     };
 
     let mut pos = &data[..];

--- a/src/parse/kdbx3.rs
+++ b/src/parse/kdbx3.rs
@@ -186,10 +186,8 @@ pub(crate) fn parse(data: &[u8], key_elements: &[Vec<u8>]) -> Result<Database, D
     let mut meta = Meta::default();
 
     let mut root = Group {
-        uuid: Default::default(),
         name: "Root".to_owned(),
-        children: Default::default(),
-        times: Default::default(),
+        ..Default::default()
     };
 
     // Parse XML data blocks

--- a/src/xml_db/dump/group.rs
+++ b/src/xml_db/dump/group.rs
@@ -14,11 +14,40 @@ impl DumpXml for Group {
     ) -> Result<(), xml::writer::Error> {
         writer.write(WriterEvent::start_element("Group"))?;
 
-        // TODO IconId
-        // TODO Notes
-
         SimpleTag("Name", &self.name).dump_xml(writer, inner_cipher)?;
         SimpleTag("UUID", &self.uuid).dump_xml(writer, inner_cipher)?;
+
+        if let Some(ref value) = self.notes {
+            SimpleTag("Notes", value).dump_xml(writer, inner_cipher)?;
+        }
+
+        if let Some(value) = self.icon_id {
+            SimpleTag("IconID", value).dump_xml(writer, inner_cipher)?;
+        }
+
+        if let Some(ref value) = self.custom_icon_uuid {
+            SimpleTag("CustomIconUUID", value).dump_xml(writer, inner_cipher)?;
+        }
+
+        self.times.dump_xml(writer, inner_cipher)?;
+
+        SimpleTag("IsExpanded", self.is_expanded).dump_xml(writer, inner_cipher)?;
+
+        if let Some(ref value) = self.default_autotype_sequence {
+            SimpleTag("DefaultAutoTypeSequence", value).dump_xml(writer, inner_cipher)?;
+        }
+
+        if let Some(ref value) = self.enable_autotype {
+            SimpleTag("EnableAutoType", value).dump_xml(writer, inner_cipher)?;
+        }
+
+        if let Some(ref value) = self.enable_searching {
+            SimpleTag("EnableSearching", value).dump_xml(writer, inner_cipher)?;
+        }
+
+        if let Some(ref value) = self.last_top_visible_entry {
+            SimpleTag("LastTopVisibleEntry", value).dump_xml(writer, inner_cipher)?;
+        }
 
         for child in &self.children {
             child.dump_xml(writer, inner_cipher)?;

--- a/src/xml_db/parse/entry.rs
+++ b/src/xml_db/parse/entry.rs
@@ -5,6 +5,7 @@ use secstr::SecStr;
 
 use crate::{
     crypt::ciphers::Cipher,
+    entry::History,
     xml_db::parse::{CustomData, FromXml, SimpleTag, SimpleXmlEvent, XmlParseError},
     AutoType, AutoTypeAssociation, Entry, Times, Value,
 };
@@ -42,7 +43,6 @@ impl FromXml for Entry {
                                 .split(|c| c == ';' || c == ',')
                                 .map(|x| x.to_owned())
                                 .collect();
-                            out.tags.sort();
                         }
                     }
                     "String" => {
@@ -52,11 +52,10 @@ impl FromXml for Entry {
                         }
                     }
                     "CustomData" => {
-                        let value = CustomData::from_xml(iterator, inner_cipher)?;
-                        // TODO
+                        out.custom_data = CustomData::from_xml(iterator, inner_cipher)?;
                     }
                     "Binary" => {
-                        let field = BinaryField::from_xml(iterator, inner_cipher)?;
+                        let _field = BinaryField::from_xml(iterator, inner_cipher)?;
                         // TODO reference into a binary field from the Meta. Might only appear in
                         // kdbx3
                     }
@@ -67,38 +66,31 @@ impl FromXml for Entry {
                         out.times = Times::from_xml(iterator, inner_cipher)?;
                     }
                     "IconID" => {
-                        let icon_id = SimpleTag::<usize>::from_xml(iterator, inner_cipher)?;
-                        // TODO
-                        // out.icon_id = icon_id;
+                        out.icon_id =
+                            SimpleTag::<Option<usize>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "CustomIconUUID" => {
-                        let icon_id = SimpleTag::<String>::from_xml(iterator, inner_cipher)?.value;
-                        // TODO
+                        out.custom_icon_uuid =
+                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "ForegroundColor" => {
-                        let color = SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?;
-                        // TODO
-                        // out.foregrpund_color = color;
+                        out.foreground_color =
+                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "BackgroundColor" => {
-                        let color = SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?;
-                        // TODO
-                        // out.background_color = color;
+                        out.background_color =
+                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "OverrideURL" => {
-                        let url = SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?;
-                        // TODO
-                        // out.override_url = color;
+                        out.override_url =
+                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "QualityCheck" => {
-                        let qc = SimpleTag::<bool>::from_xml(iterator, inner_cipher)?;
-                        // TODO
-                        // out.quality_check = qc;
+                        out.quality_check =
+                            SimpleTag::<Option<bool>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "History" => {
-                        let history = History::from_xml(iterator, inner_cipher)?;
-                        // TODO
-                        // out.history = history;
+                        out.history = History::from_xml(iterator, inner_cipher)?;
                     }
                     _ => {
                         IgnoreSubfield::from_xml(iterator, inner_cipher)?;
@@ -306,9 +298,9 @@ impl FromXml for AutoType {
                             SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "DataTransferObfuscation" => {
-                        let value =
+                        let _value =
                             SimpleTag::<Option<usize>>::from_xml(iterator, inner_cipher)?.value;
-                        // TODO
+                        // TODO probably not needed?
                     }
                     "Association" => {
                         let ata = AutoTypeAssociation::from_xml(iterator, inner_cipher)?;
@@ -382,10 +374,6 @@ impl FromXml for AutoTypeAssociation {
 
         Ok(out)
     }
-}
-
-struct History {
-    entries: Vec<Entry>,
 }
 
 impl FromXml for History {

--- a/src/xml_db/parse/group.rs
+++ b/src/xml_db/parse/group.rs
@@ -32,51 +32,39 @@ impl FromXml for Group {
                         out.name = SimpleTag::<String>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Notes" => {
-                        let notes =
+                        out.notes =
                             SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
-                        // TODO
-                        // out.notes = notes;
                     }
                     "IconID" => {
-                        let icon_id = SimpleTag::<usize>::from_xml(iterator, inner_cipher)?.value;
-                        // TODO
-                        // out.icon_id = icon_id;
+                        out.icon_id =
+                            SimpleTag::<Option<usize>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "CustomIconUUID" => {
-                        let icon_id = SimpleTag::<String>::from_xml(iterator, inner_cipher)?.value;
-                        // TODO
+                        out.custom_icon_uuid =
+                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Times" => {
                         out.times = Times::from_xml(iterator, inner_cipher)?;
                     }
                     "IsExpanded" => {
-                        let expanded = SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
-                        // TODO
-                        // out.is_expanded = expanded;
+                        out.is_expanded =
+                            SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "DefaultAutoTypeSequence" => {
-                        let ats =
+                        out.default_autotype_sequence =
                             SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
-                        // TODO
-                        // out.default_autotype_sequence = ats;
                     }
                     "EnableAutoType" => {
-                        let value =
+                        out.enable_autotype =
                             SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
-                        // TODO
-                        // out.enable_autotype = value;
                     }
                     "EnableSearching" => {
-                        let value =
+                        out.enable_searching =
                             SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
-                        // TODO
-                        // out.enable_searching = value;
                     }
                     "LastTopVisibleEntry" => {
-                        let value =
+                        out.last_top_visible_entry =
                             SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
-                        // TODO
-                        // out.last_top_visible_entry = value;
                     }
                     "Entry" => {
                         let entry = Entry::from_xml(iterator, inner_cipher)?;
@@ -104,5 +92,42 @@ impl FromXml for Group {
         let _close_tag = iterator.next().ok_or(XmlParseError::Eof)?;
 
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod parse_group_test {
+
+    use crate::{
+        xml_db::parse::{parse_test::parse_test_xml, XmlParseError},
+        Group,
+    };
+
+    #[test]
+    fn test_group() -> Result<(), XmlParseError> {
+        let _value = parse_test_xml::<Group>("<Group></Group>")?;
+
+        let value = parse_test_xml::<Group>("<Group><Notes>ASDF</Notes></Group>")?;
+        assert_eq!(value.notes, Some("ASDF".to_string()));
+
+        let value =
+            parse_test_xml::<Group>("<Group><CustomIconUUID>ASDF</CustomIconUUID></Group>")?;
+        assert_eq!(value.custom_icon_uuid, Some("ASDF".to_string()));
+
+        let value = parse_test_xml::<Group>("");
+        assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
+
+        let value = parse_test_xml::<Group>("<TestTag>SomeData</TestTag>");
+        assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
+
+        let value = parse_test_xml::<Group>("<Group></TestTag>");
+        assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
+
+        let value = parse_test_xml::<Group>("<Group>No-Characters-Allowed</Group>");
+        assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
+
+        let _value = parse_test_xml::<Group>("<Group><UnkownChildTag/></Group>")?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Now that we have a solid testing framework and the parsing and dumping infrastructure has matured, hammer out the final missing fields from the XML database

- [x] Parse and dump `Group` fields
- [x] Parse and dump `Entry` fields


BREAKING CHANGE: Adds additional fields to Group and Entry