### PR TITLE
feat: add a kp-get-version utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,7 @@ required-features = ["utilities"]
 [[bin]]
 name = "kp-show-otp"
 required-features = ["utilities", "totp"]
+
+[[bin]]
+name = "kp-get-version"
+required-features = ["utilities"]

--- a/src/bin/kp-get-version.rs
+++ b/src/bin/kp-get-version.rs
@@ -1,0 +1,23 @@
+/// utility to get the version of a KeePass database.
+use std::fs::File;
+use std::io::Read;
+
+use anyhow::Result;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(version, about)]
+struct Args {
+    /// Provide a .kdbx database
+    in_kdbx: String,
+}
+
+pub fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let mut source = File::open(args.in_kdbx)?;
+
+    let version = keepass::Database::get_version(&mut source)?;
+    println!("{}", version.to_string());
+    Ok(())
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -202,6 +202,9 @@ pub enum DatabaseIntegrityError {
 
     #[error(transparent)]
     KdfSettings(#[from] KdfSettingsError),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 #[derive(Debug, Error)]
@@ -361,6 +364,16 @@ impl Database {
         };
 
         Ok(data)
+    }
+
+    /// Get the version of a database.
+    pub fn get_version(
+        source: &mut dyn std::io::Read,
+    ) -> Result<DatabaseVersion, DatabaseIntegrityError> {
+        let mut data = Vec::new();
+        data.resize(DatabaseVersion::get_version_header_size(), 0);
+        source.read(&mut data)?;
+        DatabaseVersion::parse(data.as_ref())
     }
 
     pub fn new(

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -81,6 +81,17 @@ impl DatabaseVersion {
     }
 }
 
+impl ToString for DatabaseVersion {
+    fn to_string(&self) -> String {
+        match self {
+            DatabaseVersion::KDB(_) => "KDB".to_string(),
+            DatabaseVersion::KDB2(_) => "KDBX2".to_string(),
+            DatabaseVersion::KDB3(minor_version) => format!("KDBX3.{}", minor_version),
+            DatabaseVersion::KDB4(minor_version) => format!("KDBX4.{}", minor_version),
+        }
+    }
+}
+
 /// Read the KDBX header to get the file version
 pub fn get_kdbx_version(data: &[u8]) -> Result<(u32, u16, u16), DatabaseIntegrityError> {
     // check identifier

--- a/tests/file_read_tests.rs
+++ b/tests/file_read_tests.rs
@@ -305,4 +305,17 @@ mod file_read_tests {
         }
         Ok(())
     }
+
+    #[test]
+    fn test_get_version() -> Result<(), DatabaseIntegrityError> {
+        let path = Path::new("tests/resources/test_db_with_password.kdbx");
+        let version = Database::get_version(&mut File::open(path)?)?;
+        assert_eq!(version.to_string(), "KDBX3.1");
+
+        let path = Path::new("tests/resources/test_db_kdbx4_with_password_argon2.kdbx");
+        let version = Database::get_version(&mut File::open(path)?)?;
+        assert_eq!(version.to_string(), "KDBX4.0");
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
This can be useful for doing basic sanity checks on keepass database, to make sure that they have not been corrupted.
I think in the future we could merge some of the utilities into a single CLI binary, which would make it easier to discover the different features offered by the binaries in the crate.