### PR TITLE
ci: prevent ci failure from coverage job

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,6 +8,7 @@ name: Merge on Master
 jobs:
   coverage:
     name: Code Coverage
+    continue-on-error: true
     runs-on: ubuntu-latest
     container:
       image: xd009642/tarpaulin:0.24.0

--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -2,5 +2,6 @@
 all-features = true
 workspace = true
 target-dir = "target/coverage/"
+fail-under = 80
 exclude-files = ["src/bin/*", "target/*"]
 out = ["Xml", "Html"]


### PR DESCRIPTION
This job keeps failing as soon as the coverage drops even by a single line. I didn't find any tarpaulin or `codecov-action` option to disable that behavior, so I suggest we just ignore the failures for the moment. I'm also setting the `fail-under` option to make it explicit what our current coverage target is.