### PR TITLE
docs: use full project name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# keepass
+# keepass-rs
 
 [![Crates.io](https://img.shields.io/crates/v/keepass.svg)](https://crates.io/crates/keepass)
 [![Documentation](https://docs.rs/keepass/badge.svg)](https://docs.rs/keepass/)
@@ -7,7 +7,7 @@
 [![dependency status](https://deps.rs/repo/github/sseemayer/keepass-rs/status.svg)](https://deps.rs/repo/github/sseemayer/keepass-rs)
 [![License file](https://img.shields.io/github/license/sseemayer/keepass-rs)](https://github.com/sseemayer/keepass-rs/blob/master/LICENSE)
 
-Rust KeePass database file parser for KDB KDBX3 and KDBX4, with experimental support for KDBX4 writing.
+Rust KeePass database file parser for KDB, KDBX3 and KDBX4, with experimental support for KDBX4 writing.
 
 ## Example
 ```rust


### PR DESCRIPTION
To make sure that there's no ambiguity about the project name, if accessed from the source code directly instead of github.