### PR TITLE
feat: regenerate the ivs on db save

### DIFF
--- a/src/bin/kp-rewrite.rs
+++ b/src/bin/kp-rewrite.rs
@@ -44,7 +44,7 @@ pub fn main() -> Result<()> {
         None
     };
 
-    let db = Database::open(
+    let mut db = Database::open(
         &mut source,
         password,
         keyfile.as_mut().map(|kf| kf as &mut dyn Read),


### PR DESCRIPTION
This commit extract a `generate_ivs` function so that we can generate new IVs both when creating a new database and when saving an existing database. The new unit test is a bit too weak, because we only test test `master_seed`, and because we don't validate that the IVs were regenerated *before* dumping the encrypted database. I'm not sure yet how we could improve that. I tried comparing the raw encrypted databases, but they already differ when using the `master` codebase, I'm guessing because of another source of randomness in the encryption process.