### PR TITLE
ci: avoid codecov patch failures

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,6 @@ name: Merge on Master
 jobs:
   coverage:
     name: Code Coverage
-    continue-on-error: true
     runs-on: ubuntu-latest
     container:
       image: xd009642/tarpaulin:0.24.0
@@ -20,5 +19,5 @@ jobs:
           cargo tarpaulin --verbose --timeout 120
       - uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,9 @@ coverage:
         # This is the allowed decrease in coverage before we
         # throw an error.
         threshold: 10%
+    patch:
+      default:
+        target: 80%
+        # This is the allowed decrease in coverage before we
+        # throw an error.
+        threshold: 10%


### PR DESCRIPTION
I think I finally found out what the problem was. The `status` codecov job was configured, but we were not configuring the `patch` job, as documented [here](https://docs.codecov.com/docs/commit-status#patch-status). It should now only fail if the coverage goes below 80%, or if the coverage drops by more than 10% in a single commit.

I also removed the `fail_ci_if_error`. Excerpt from the [doc](https://github.com/codecov/codecov-action#arguments):
```
Specify if CI pipeline should fail when Codecov runs into errors during upload.
```
I think we want visibility on upload errors, so that we can troubleshoot what happened and fix the workflow.