### PR TITLE
fix: pin the minor kdbx4 version to 0

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -31,7 +31,7 @@ use crate::{
         kdb::KDBHeader,
         kdbx3::KDBX3Header,
         kdbx4::{KDBX4Header, KDBX4InnerHeader},
-        DatabaseVersion,
+        DatabaseVersion, KDBX4_CURRENT_MINOR_VERSION,
     },
     hmac_block_stream::BlockStreamError,
     keyfile::KeyfileError,
@@ -439,7 +439,7 @@ impl Database {
     pub fn new(settings: NewDatabaseSettings) -> std::result::Result<Database, DatabaseNewError> {
         let mut database = Database {
             header: Header::KDBX4(KDBX4Header {
-                version: DatabaseVersion::KDB4(3),
+                version: DatabaseVersion::KDB4(KDBX4_CURRENT_MINOR_VERSION),
                 outer_cipher: settings.outer_cipher_suite,
                 compression: settings.compression,
                 master_seed: vec![],

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -18,6 +18,8 @@ pub const KEEPASS_LATEST_ID: u32 = 0xb54bfb67;
 pub const KDBX3_MAJOR_VERSION: u16 = 3;
 pub const KDBX4_MAJOR_VERSION: u16 = 4;
 
+pub const KDBX4_CURRENT_MINOR_VERSION: u16 = 0;
+
 /// Supported KDB database versions, with the associated
 /// minor version.
 #[derive(Debug)]


### PR DESCRIPTION
I'm not sure where I took `3` from, but the minor value I'm getting when creating a database from KeePassXC is `0`. I also saw `4.1`, but I'm unable to recreate a database with that minor version. It might be related to the KDF or encryption schemes used.