### PR TITLE
refactor!: never store keys or seeds

### DIFF
--- a/src/bin/kp-dump-xml.rs
+++ b/src/bin/kp-dump-xml.rs
@@ -13,6 +13,9 @@ struct Args {
     /// Provide a .kdbx database
     in_kdbx: String,
 
+    /// Output XML filename
+    out_xml: String,
+
     /// Provide a keyfile
     #[arg(short = 'k', long)]
     keyfile: Option<String>,
@@ -33,20 +36,13 @@ pub fn main() -> Result<()> {
         Some(&password[..])
     };
 
-    let chunks = Database::get_xml_chunks(
+    let xml = Database::get_xml(
         &mut source,
         password,
         keyfile.as_mut().map(|kf| kf as &mut dyn Read),
     )?;
 
-    for (i, chunk) in chunks.iter().enumerate() {
-        let chunk_fn = format!("db-{}.xml", i);
-        let mut chunk_file = File::create(chunk_fn).expect("Open chunk XML file");
-
-        chunk_file.write(chunk)?;
-    }
-
-    println!("Wrote {} chunks", chunks.len());
+    File::create(args.out_xml)?.write_all(&xml)?;
 
     Ok(())
 }

--- a/src/bin/kp-rewrite.rs
+++ b/src/bin/kp-rewrite.rs
@@ -44,7 +44,7 @@ pub fn main() -> Result<()> {
         None
     };
 
-    let mut db = Database::open(
+    let db = Database::open(
         &mut source,
         password,
         keyfile.as_mut().map(|kf| kf as &mut dyn Read),

--- a/src/format/kdbx4/dump.rs
+++ b/src/format/kdbx4/dump.rs
@@ -4,16 +4,19 @@ use byteorder::{LittleEndian, WriteBytesExt};
 
 use crate::{
     crypt,
-    db::{Database, Header, InnerHeader},
-    format::kdbx4::{
-        KDBX4Header, KDBX4InnerHeader, HEADER_COMPRESSION_ID, HEADER_ENCRYPTION_IV, HEADER_END,
-        HEADER_KDF_PARAMS, HEADER_MASTER_SEED, HEADER_OUTER_ENCRYPTION_ID,
-        INNER_HEADER_BINARY_ATTACHMENTS, INNER_HEADER_END, INNER_HEADER_RANDOM_STREAM_ID,
-        INNER_HEADER_RANDOM_STREAM_KEY,
+    db::Database,
+    format::{
+        kdbx4::{
+            KDBX4InnerHeader, KDBX4OuterHeader, HEADER_COMPRESSION_ID, HEADER_ENCRYPTION_IV,
+            HEADER_END, HEADER_KDF_PARAMS, HEADER_MASTER_SEED, HEADER_MASTER_SEED_SIZE,
+            HEADER_OUTER_ENCRYPTION_ID, INNER_HEADER_BINARY_ATTACHMENTS, INNER_HEADER_END,
+            INNER_HEADER_RANDOM_STREAM_ID, INNER_HEADER_RANDOM_STREAM_KEY,
+        },
+        DatabaseVersion,
     },
     hmac_block_stream,
     io::WriteLengthTaggedExt,
-    meta::BinaryAttachment,
+    meta::{BinaryAttachment, BinaryAttachments},
     variant_dictionary::VariantDictionary,
     DatabaseSaveError,
 };
@@ -24,14 +27,35 @@ pub fn dump_kdbx4(
     key_elements: &[Vec<u8>],
     writer: &mut dyn Write,
 ) -> Result<(), DatabaseSaveError> {
-    let header = match &db.header {
-        Header::KDBX4(h) => h,
-        _ => return Err(DatabaseSaveError::UnsupportedVersion.into()),
-    };
+    if !matches!(db.settings.version, DatabaseVersion::KDB4(_)) {
+        return Err(DatabaseSaveError::UnsupportedVersion.into());
+    }
+
+    // generate encryption keys and seeds on the fly when saving
+    let mut master_seed = vec![0; HEADER_MASTER_SEED_SIZE];
+    getrandom::getrandom(&mut master_seed)?;
+
+    let mut outer_iv = vec![0; db.settings.outer_cipher_suite.get_iv_size()];
+    getrandom::getrandom(&mut outer_iv)?;
+
+    let mut inner_random_stream_key = vec![0; db.settings.inner_cipher_suite.get_key_size()];
+    getrandom::getrandom(&mut inner_random_stream_key)?;
+
+    let mut kdf_seed = vec![0; db.settings.kdf_settings.seed_size()];
+    getrandom::getrandom(&mut kdf_seed)?;
 
     // dump the outer header - need to buffer so that SHA256 can be computed
     let mut header_data = Vec::new();
-    header.dump(&mut header_data)?;
+    KDBX4OuterHeader {
+        version: db.settings.version.clone(),
+        outer_cipher_suite: db.settings.outer_cipher_suite.clone(),
+        compression: db.settings.compression.clone(),
+        master_seed: master_seed.clone(),
+        outer_iv: outer_iv.clone(),
+        kdf_settings: db.settings.kdf_settings.clone(),
+        kdf_seed: kdf_seed.clone(),
+    }
+    .dump(&mut header_data)?;
 
     let header_sha256 = crypt::calculate_sha256(&[&header_data])?;
 
@@ -42,38 +66,47 @@ pub fn dump_kdbx4(
     // derive master key from composite key, transform_seed, transform_rounds and master_seed
     let key_elements: Vec<&[u8]> = key_elements.iter().map(|v| &v[..]).collect();
     let composite_key = crypt::calculate_sha256(&key_elements)?;
-    let transformed_key = header.kdf.get_kdf().transform_key(&composite_key)?;
-    let master_key = crypt::calculate_sha256(&[header.master_seed.as_ref(), &transformed_key])?;
+    let transformed_key = db
+        .settings
+        .kdf_settings
+        .get_kdf(&kdf_seed)
+        .transform_key(&composite_key)?;
+    let master_key = crypt::calculate_sha256(&[&master_seed, &transformed_key])?;
 
     // verify credentials
-    let hmac_key = crypt::calculate_sha512(&[&header.master_seed, &transformed_key, b"\x01"])?;
+    let hmac_key = crypt::calculate_sha512(&[&master_seed, &transformed_key, b"\x01"])?;
     let header_hmac_key = hmac_block_stream::get_hmac_block_key(u64::max_value(), &hmac_key)?;
     let header_hmac = crypt::calculate_hmac(&[&header_data], &header_hmac_key)?;
 
     writer.write(&header_hmac)?;
 
-    let inner_header = match &db.inner_header {
-        InnerHeader::KDBX4(h) => h,
-        _ => return Err(DatabaseSaveError::UnsupportedVersion.into()),
-    };
+    // Initialize inner encryptor from inner header params
+    let mut inner_cipher = db
+        .settings
+        .inner_cipher_suite
+        .get_cipher(&inner_random_stream_key)?;
 
     // dump inner header into buffer
     let mut payload = Vec::new();
-    inner_header.dump(&mut payload)?;
-
-    // Initialize inner decryptor from inner header params
-    let mut inner_cipher = inner_header
-        .inner_random_stream
-        .get_cipher(&inner_header.inner_random_stream_key)?;
+    KDBX4InnerHeader {
+        inner_random_stream: db.settings.inner_cipher_suite.clone(),
+        inner_random_stream_key,
+    }
+    .dump(&db.header_attachments, &mut payload)?;
 
     // after inner header is one XML document
     crate::xml_db::dump::dump(&db, &mut *inner_cipher, &mut payload)?;
 
-    let payload_compressed = header.compression.get_compression().compress(&payload)?;
+    let payload_compressed = db
+        .settings
+        .compression
+        .get_compression()
+        .compress(&payload)?;
 
-    let payload_encrypted = header
-        .outer_cipher
-        .get_cipher(&master_key, header.outer_iv.as_ref())?
+    let payload_encrypted = db
+        .settings
+        .outer_cipher_suite
+        .get_cipher(&master_key, &outer_iv)?
         .encrypt(&payload_compressed)?;
 
     let payload_hmac = hmac_block_stream::write_hmac_block_stream(&payload_encrypted, &hmac_key)?;
@@ -90,12 +123,12 @@ impl BinaryAttachment {
     }
 }
 
-impl KDBX4Header {
+impl KDBX4OuterHeader {
     fn dump(&self, writer: &mut dyn Write) -> Result<(), DatabaseSaveError> {
         self.version.dump(writer)?;
 
         writer.write_u8(HEADER_OUTER_ENCRYPTION_ID)?;
-        writer.write_with_len(&self.outer_cipher.dump())?;
+        writer.write_with_len(&self.outer_cipher_suite.dump())?;
 
         writer.write_u8(HEADER_COMPRESSION_ID)?;
         writer.write_with_len(&self.compression.dump())?;
@@ -106,7 +139,7 @@ impl KDBX4Header {
         writer.write_u8(HEADER_MASTER_SEED)?;
         writer.write_with_len(&self.master_seed)?;
 
-        let vd: VariantDictionary = self.kdf.to_variant_dictionary();
+        let vd: VariantDictionary = self.kdf_settings.to_variant_dictionary(&self.kdf_seed);
         let mut vd_buffer = Vec::new();
         vd.dump(&mut vd_buffer)?;
 
@@ -121,7 +154,11 @@ impl KDBX4Header {
 }
 
 impl KDBX4InnerHeader {
-    fn dump(&self, writer: &mut dyn Write) -> Result<(), DatabaseSaveError> {
+    fn dump(
+        &self,
+        binaries: &BinaryAttachments,
+        writer: &mut dyn Write,
+    ) -> Result<(), DatabaseSaveError> {
         writer.write(&[INNER_HEADER_RANDOM_STREAM_ID])?;
         writer.write_u32::<LittleEndian>(4)?;
         writer.write_u32::<LittleEndian>(self.inner_random_stream.dump())?;
@@ -129,7 +166,7 @@ impl KDBX4InnerHeader {
         writer.write_u8(INNER_HEADER_RANDOM_STREAM_KEY)?;
         writer.write_with_len(&self.inner_random_stream_key)?;
 
-        for binary in &self.binaries {
+        for binary in &binaries.binaries {
             writer.write_u8(INNER_HEADER_BINARY_ATTACHMENTS)?;
             writer.write_u32::<LittleEndian>((binary.content.len() + 1) as u32)?;
             binary.dump(writer)?;

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -24,7 +24,8 @@ pub const KDBX4_CURRENT_MINOR_VERSION: u16 = 0;
 
 /// Supported KDB database versions, with the associated
 /// minor version.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub enum DatabaseVersion {
     KDB(u16),
     KDB2(u16),

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -95,7 +95,7 @@ mod tests {
 
         root_group.children.push(Node::Entry(entry.clone()));
 
-        let mut db = Database::new(crate::NewDatabaseSettings::default()).unwrap();
+        let mut db = Database::new(crate::DatabaseSettings::default()).unwrap();
         db.root = root_group;
 
         let key_elements = make_key();
@@ -146,7 +146,7 @@ mod tests {
 
         root_group.children.push(Node::Group(subgroup));
 
-        let mut db = Database::new(crate::NewDatabaseSettings::default()).unwrap();
+        let mut db = Database::new(crate::DatabaseSettings::default()).unwrap();
         db.root = root_group.clone();
 
         let key_elements = make_key();
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     pub fn test_meta() {
-        let mut db = Database::new(crate::NewDatabaseSettings::default()).unwrap();
+        let mut db = Database::new(crate::DatabaseSettings::default()).unwrap();
 
         let meta = Meta {
             generator: Some("test-generator".to_string()),


### PR DESCRIPTION
Instead of overwriting the various key seeds and IVs and testing that they were overwritten, only keep the buffers around during parsing and dynamically regenerate them during dumping.

BREAKING CHANGE: Database interface changed so that headers are not exposed directly anymore, but instead only DatabaseSettings are.