### PR TITLE
ci: disable target for differential coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ coverage:
         threshold: 10%
     patch:
       default:
-        target: 80%
+        target: 0%
         # This is the allowed decrease in coverage before we
         # throw an error.
         threshold: 10%


### PR DESCRIPTION
The latest merges in `master` didn't fail, but I still think the patch behavior will cause problems in the future. The current `patch` config would fail if <80% of the **new** code is not covered. I think this is not useful because we already enforce a target for the overall codebase, and we will fail if the overall coverage drops by >10%.

There's a [`dry_run`](https://github.com/codecov/codecov-action#arguments) option in the codecov action that prevents the step from uploading the results. I think we could use that to also enforce the current coverage from within the PRs. This would allow us to enforce a certain coverage % before merging to master. We can wait until the library is more stable to enable that.