### PR TITLE
refactor!: split BinaryAttachment and HeaderAttachment

### DIFF
--- a/src/db/meta.rs
+++ b/src/db/meta.rs
@@ -101,7 +101,6 @@ pub struct BinaryAttachments {
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct BinaryAttachment {
     pub identifier: Option<String>,
-    pub flags: u8,
     pub compressed: bool,
     pub content: Vec<u8>,
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -27,7 +27,6 @@ use crate::{
         KdfSettingsError, OuterCipherSuite, OuterCipherSuiteError,
     },
     crypt::{calculate_sha256, CryptographyError},
-    db::meta::BinaryAttachments,
     format::{
         kdb::parse_kdb,
         kdbx3::{decrypt_kdbx3, parse_kdbx3},
@@ -48,7 +47,7 @@ pub struct Database {
     pub settings: DatabaseSettings,
 
     /// Binary attachments in the inner header
-    pub header_attachments: BinaryAttachments,
+    pub header_attachments: Vec<HeaderAttachment>,
 
     /// Root node of the KeePass database
     pub root: Group,
@@ -418,7 +417,7 @@ impl Database {
     pub fn new(settings: DatabaseSettings) -> std::result::Result<Database, DatabaseNewError> {
         let database = Database {
             settings,
-            header_attachments: BinaryAttachments::default(),
+            header_attachments: Vec::new(),
             root: Group::new("Root"),
             meta: Default::default(),
         };
@@ -460,4 +459,11 @@ pub struct CustomDataItem {
     pub key: String,
     pub value: Option<Value>,
     pub last_modification_time: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+pub struct HeaderAttachment {
+    pub flags: u8,
+    pub content: Vec<u8>,
 }

--- a/src/format/kdbx3.rs
+++ b/src/format/kdbx3.rs
@@ -4,7 +4,6 @@ use crate::{
     db::{Database, DatabaseKeyError, DatabaseOpenError},
     format::DatabaseVersion,
     hmac_block_stream::BlockStreamError,
-    meta::BinaryAttachments,
     DatabaseIntegrityError, DatabaseSettings,
 };
 
@@ -174,7 +173,7 @@ pub(crate) fn parse_kdbx3(
 
     let db = Database {
         settings,
-        header_attachments: BinaryAttachments::default(),
+        header_attachments: Vec::new(),
         root: database_content.root.group,
         meta: database_content.meta,
     };

--- a/src/format/kdbx4/mod.rs
+++ b/src/format/kdbx4/mod.rs
@@ -52,7 +52,7 @@ mod kdbx4_tests {
     use crate::{
         config::{Compression, InnerCipherSuite, KdfSettings, OuterCipherSuite},
         format::{kdbx4::dump::dump_kdbx4, KDBX4_CURRENT_MINOR_VERSION},
-        BinaryAttachment, Database, DatabaseSettings, Entry, Group, Node, Value,
+        Database, DatabaseSettings, Entry, Group, HeaderAttachment, Node, Value,
     };
 
     fn test_with_settings(
@@ -245,23 +245,19 @@ mod kdbx4_tests {
     }
 
     #[test]
-    pub fn binary_attachments() {
+    pub fn header_attachments() {
         let mut root_group = Group::new("Root");
         root_group.children.push(Node::Entry(Entry::new()));
 
         let mut db = Database::new(DatabaseSettings::default()).unwrap();
 
-        db.header_attachments.binaries = vec![
-            BinaryAttachment {
-                identifier: None,
+        db.header_attachments = vec![
+            HeaderAttachment {
                 flags: 1,
-                compressed: false,
                 content: vec![0x01, 0x02, 0x03, 0x04],
             },
-            BinaryAttachment {
-                identifier: None,
+            HeaderAttachment {
                 flags: 2,
-                compressed: false,
                 content: vec![0x04, 0x03, 0x02, 0x01],
             },
         ];
@@ -284,9 +280,9 @@ mod kdbx4_tests {
 
         assert_eq!(decrypted_db.root.children.len(), 1);
 
-        let binaries = &decrypted_db.header_attachments.binaries;
-        assert_eq!(binaries.len(), 2);
-        assert_eq!(binaries[0].flags, 1);
-        assert_eq!(binaries[0].content, [0x01, 0x02, 0x03, 0x04]);
+        let header_attachments = &decrypted_db.header_attachments;
+        assert_eq!(header_attachments.len(), 2);
+        assert_eq!(header_attachments[0].flags, 1);
+        assert_eq!(header_attachments[0].content, [0x01, 0x02, 0x03, 0x04]);
     }
 }

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -212,19 +212,16 @@ mod tests {
                 binaries: vec![
                     BinaryAttachment {
                         identifier: Some("1".to_string()),
-                        flags: 0,
                         compressed: false,
                         content: b"i am binary data".to_vec(),
                     },
                     BinaryAttachment {
                         identifier: Some("2".to_string()),
-                        flags: 0,
                         compressed: true,
                         content: b"i am compressed binary data".to_vec(),
                     },
                     BinaryAttachment {
                         identifier: None,
-                        flags: 0,
                         compressed: true,
                         content: b"i am compressed binary data without an identifier".to_vec(),
                     },


### PR DESCRIPTION
Closes #117

Since the fields for an attachment inside of a <Meta> tag and inside of a KDBX4 binary header are different, make the distinction explicit by splitting up the types

BREAKING CHANGE: New type for header_attachments field in Database
BREAKING CHANGE: Fewer members for BinaryAttachment parsed from XML