### PR TITLE
refactor: extract hmac key end magic value

### DIFF
--- a/src/format/kdbx4/dump.rs
+++ b/src/format/kdbx4/dump.rs
@@ -74,7 +74,11 @@ pub fn dump_kdbx4(
     let master_key = crypt::calculate_sha256(&[&master_seed, &transformed_key])?;
 
     // verify credentials
-    let hmac_key = crypt::calculate_sha512(&[&master_seed, &transformed_key, b"\x01"])?;
+    let hmac_key = crypt::calculate_sha512(&[
+        &master_seed,
+        &transformed_key,
+        &hmac_block_stream::HMAC_KEY_END,
+    ])?;
     let header_hmac_key = hmac_block_stream::get_hmac_block_key(u64::max_value(), &hmac_key)?;
     let header_hmac = crypt::calculate_hmac(&[&header_data], &header_hmac_key)?;
 

--- a/src/format/kdbx4/parse.rs
+++ b/src/format/kdbx4/parse.rs
@@ -98,8 +98,11 @@ pub(crate) fn decrypt_kdbx4(
     }
 
     // verify credentials
-    let hmac_key =
-        crypt::calculate_sha512(&[&outer_header.master_seed, &transformed_key, b"\x01"])?;
+    let hmac_key = crypt::calculate_sha512(&[
+        &outer_header.master_seed,
+        &transformed_key,
+        &hmac_block_stream::HMAC_KEY_END,
+    ])?;
     let header_hmac_key = hmac_block_stream::get_hmac_block_key(u64::max_value(), &hmac_key)?;
     if header_hmac != crypt::calculate_hmac(&[header_data], &header_hmac_key)?.as_slice() {
         return Err(DatabaseKeyError::IncorrectKey.into());

--- a/src/hmac_block_stream.rs
+++ b/src/hmac_block_stream.rs
@@ -1,8 +1,11 @@
 use byteorder::{ByteOrder, LittleEndian};
 use cipher::generic_array::{typenum::U64, GenericArray};
+use hex_literal::hex;
 use thiserror::Error;
 
 use crate::crypt::CryptographyError;
+
+pub const HMAC_KEY_END: [u8; 1] = hex!("01");
 
 #[derive(Debug, Error)]
 pub enum BlockStreamError {


### PR DESCRIPTION
Extract another magic value that was duplicated between the parsing and dumping code into a constant.