### PR TITLE
refactor!: clean up error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ twofish = "0.7"
 cbc = "0.1"
 
 uuid = { version = "1.2", features = ["v4"] }
-getrandom = { version = "0.2" }
+getrandom = { version = "0.2", features = ["std"] }
 
 # dependencies for command-line utilities
 anyhow = { version = "1", optional = true }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -209,14 +209,8 @@ pub enum DatabaseSaveError {
     #[error(transparent)]
     Cryptography(#[from] CryptographyError),
 
-    #[error("Error generating random data: {}", _0)]
-    Random(String),
-}
-
-impl From<getrandom::Error> for DatabaseSaveError {
-    fn from(e: getrandom::Error) -> Self {
-        DatabaseSaveError::Random(format!("{}", e))
-    }
+    #[error(transparent)]
+    Random(#[from] getrandom::Error),
 }
 
 impl From<CryptographyError> for DatabaseOpenError {
@@ -264,18 +258,6 @@ impl From<VariantDictionaryError> for DatabaseOpenError {
 impl From<CompressionError> for DatabaseOpenError {
     fn from(e: CompressionError) -> Self {
         DatabaseIntegrityError::from(e).into()
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum DatabaseNewError {
-    #[error("Error generating random data: {}", _0)]
-    Random(String),
-}
-
-impl From<getrandom::Error> for DatabaseNewError {
-    fn from(e: getrandom::Error) -> Self {
-        DatabaseNewError::Random(format!("{}", e))
     }
 }
 
@@ -414,14 +396,13 @@ impl Database {
         DatabaseVersion::parse(data.as_ref())
     }
 
-    pub fn new(settings: DatabaseSettings) -> std::result::Result<Database, DatabaseNewError> {
-        let database = Database {
+    pub fn new(settings: DatabaseSettings) -> Database {
+        Self {
             settings,
             header_attachments: Vec::new(),
             root: Group::new("Root"),
             meta: Default::default(),
-        };
-        Ok(database)
+        }
     }
 }
 

--- a/src/format/kdbx4/mod.rs
+++ b/src/format/kdbx4/mod.rs
@@ -67,8 +67,7 @@ mod kdbx4_tests {
             compression,
             inner_cipher_suite,
             kdf_settings: kdf_setting,
-        })
-        .unwrap();
+        });
 
         let mut root_group = Group::new("Root");
         root_group.children.push(Node::Entry(Entry::new()));
@@ -249,7 +248,7 @@ mod kdbx4_tests {
         let mut root_group = Group::new("Root");
         root_group.children.push(Node::Entry(Entry::new()));
 
-        let mut db = Database::new(DatabaseSettings::default()).unwrap();
+        let mut db = Database::new(DatabaseSettings::default());
 
         db.header_attachments = vec![
             HeaderAttachment {

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -95,7 +95,7 @@ mod tests {
 
         root_group.children.push(Node::Entry(entry.clone()));
 
-        let mut db = Database::new(crate::DatabaseSettings::default()).unwrap();
+        let mut db = Database::new(crate::DatabaseSettings::default());
         db.root = root_group;
 
         let key_elements = make_key();
@@ -146,7 +146,7 @@ mod tests {
 
         root_group.children.push(Node::Group(subgroup));
 
-        let mut db = Database::new(crate::DatabaseSettings::default()).unwrap();
+        let mut db = Database::new(crate::DatabaseSettings::default());
         db.root = root_group.clone();
 
         let key_elements = make_key();
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     pub fn test_meta() {
-        let mut db = Database::new(crate::DatabaseSettings::default()).unwrap();
+        let mut db = Database::new(crate::DatabaseSettings::default());
 
         let meta = Meta {
             generator: Some("test-generator".to_string()),


### PR DESCRIPTION
Properly chain getrandom::Error and make Database::new infallible since no more random data needs to be generated

BREAKING CHANGE: Database::new returns Self instead of Result<Self>.
BREAKING CHANGE: DatabaseSaveError::Random contains the actual Error type inside it.