### PR TITLE
refactor!: clean up public interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,22 @@ Rust KeePass database file parser for KDB, KDBX3 and KDBX4, with experimental su
 
 ## Example
 ```rust
+use anyhow::Result;
 use keepass::{
-    db::{Database, NodeRef},
-    error::DatabaseOpenError,
-    Key
+    db::NodeRef,
+    Database, DatabaseKey
 };
 use std::fs::File;
 
-fn main() -> Result<(), DatabaseOpenError> {
+fn main() -> Result<()> {
     // Open KeePass database
     let path = std::path::Path::new("tests/resources/test_db_with_password.kdbx");
     let db = Database::open(
-        &mut File::open(path)?,         // the database
-        Key::with_password("demopass"), // password (keyfile is also supported)
+        &mut File::open(path)?,         		// the database
+        DatabaseKey::with_password("demopass"), // password (keyfile is also supported)
     )?;
 
-    // Iterate over all Groups and Nodes
+    // Iterate over all `Group`s and `Entry`s
     for node in &db.root {
         match node {
             NodeRef::Group(g) => {
@@ -85,14 +85,13 @@ You can enable the experimental support for saving KDBX4 databases using the `sa
 ```rust ignore
 use anyhow::Result;
 use keepass::{
-    db::{Database, DatabaseSettings, Entry, Group, Node, NodeRef, Value},
-    error::DatabaseOpenError,
-    Key
+    db::{Database, Entry, Group, Node, NodeRef, Value},
+    DatabaseKey
 };
 use std::fs::File;
 
 fn main() -> Result<()> {
-    let mut db = Database::new(DatabaseSettings::default())?;
+    let mut db = Database::new(Default::default())?;
 
     db.meta.database_name = Some("Demo database".to_string());
 
@@ -109,7 +108,7 @@ fn main() -> Result<()> {
 
     db.save(
         &mut File::create("demo.kdbx")?,
-        Key::with_password("demopass"),
+        DatabaseKey::with_password("demopass"),
     )?;
 
     Ok(())

--- a/src/bin/kp-dump-json.rs
+++ b/src/bin/kp-dump-json.rs
@@ -4,7 +4,7 @@ use std::{fs::File, io::Read};
 use anyhow::Result;
 use clap::Parser;
 
-use keepass::{Database, Key};
+use keepass::{Database, DatabaseKey};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -34,7 +34,7 @@ pub fn main() -> Result<()> {
 
     let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
 
-    let db = Database::open(&mut source, Key { password, keyfile })?;
+    let db = Database::open(&mut source, DatabaseKey { password, keyfile })?;
 
     let stdout = std::io::stdout().lock();
     serde_json::ser::to_writer(stdout, &db)?;

--- a/src/bin/kp-dump-json.rs
+++ b/src/bin/kp-dump-json.rs
@@ -4,7 +4,7 @@ use std::{fs::File, io::Read};
 use anyhow::Result;
 use clap::Parser;
 
-use keepass::Database;
+use keepass::{Database, Key};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -32,11 +32,9 @@ pub fn main() -> Result<()> {
         Some(&password[..])
     };
 
-    let db = Database::open(
-        &mut source,
-        password,
-        keyfile.as_mut().map(|kf| kf as &mut dyn Read),
-    )?;
+    let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
+
+    let db = Database::open(&mut source, Key { password, keyfile })?;
 
     let stdout = std::io::stdout().lock();
     serde_json::ser::to_writer(stdout, &db)?;

--- a/src/bin/kp-dump-xml.rs
+++ b/src/bin/kp-dump-xml.rs
@@ -5,7 +5,7 @@ use std::io::{Read, Write};
 use anyhow::Result;
 use clap::Parser;
 
-use keepass::{Database, Key};
+use keepass::{Database, DatabaseKey};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -38,7 +38,7 @@ pub fn main() -> Result<()> {
 
     let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
 
-    let xml = Database::get_xml(&mut source, Key { password, keyfile })?;
+    let xml = Database::get_xml(&mut source, DatabaseKey { password, keyfile })?;
 
     File::create(args.out_xml)?.write_all(&xml)?;
 

--- a/src/bin/kp-dump-xml.rs
+++ b/src/bin/kp-dump-xml.rs
@@ -5,7 +5,7 @@ use std::io::{Read, Write};
 use anyhow::Result;
 use clap::Parser;
 
-use keepass::Database;
+use keepass::{Database, Key};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -36,11 +36,9 @@ pub fn main() -> Result<()> {
         Some(&password[..])
     };
 
-    let xml = Database::get_xml(
-        &mut source,
-        password,
-        keyfile.as_mut().map(|kf| kf as &mut dyn Read),
-    )?;
+    let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
+
+    let xml = Database::get_xml(&mut source, Key { password, keyfile })?;
 
     File::create(args.out_xml)?.write_all(&xml)?;
 

--- a/src/bin/kp-rewrite.rs
+++ b/src/bin/kp-rewrite.rs
@@ -5,7 +5,7 @@ use std::io::{Cursor, Read};
 use anyhow::Result;
 use clap::Parser;
 
-use keepass::Database;
+use keepass::{Database, Key};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -46,14 +46,18 @@ pub fn main() -> Result<()> {
 
     let db = Database::open(
         &mut source,
-        password,
-        keyfile.as_mut().map(|kf| kf as &mut dyn Read),
+        Key {
+            password,
+            keyfile: keyfile.as_mut().map(|kf| kf as &mut dyn Read),
+        },
     )?;
 
     db.save(
         &mut File::create(args.out_kdbx)?,
-        password,
-        keyfile.as_mut().map(|kf| kf as &mut dyn Read),
+        Key {
+            password,
+            keyfile: keyfile.as_mut().map(|kf| kf as &mut dyn Read),
+        },
     )?;
 
     Ok(())

--- a/src/bin/kp-rewrite.rs
+++ b/src/bin/kp-rewrite.rs
@@ -5,7 +5,7 @@ use std::io::{Cursor, Read};
 use anyhow::Result;
 use clap::Parser;
 
-use keepass::{Database, Key};
+use keepass::{Database, DatabaseKey};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -46,7 +46,7 @@ pub fn main() -> Result<()> {
 
     let db = Database::open(
         &mut source,
-        Key {
+        DatabaseKey {
             password,
             keyfile: keyfile.as_mut().map(|kf| kf as &mut dyn Read),
         },
@@ -54,7 +54,7 @@ pub fn main() -> Result<()> {
 
     db.save(
         &mut File::create(args.out_kdbx)?,
-        Key {
+        DatabaseKey {
             password,
             keyfile: keyfile.as_mut().map(|kf| kf as &mut dyn Read),
         },

--- a/src/bin/kp-show-db.rs
+++ b/src/bin/kp-show-db.rs
@@ -5,7 +5,7 @@ use std::io::Read;
 use anyhow::Result;
 use clap::Parser;
 
-use keepass::{Database, Key};
+use keepass::{Database, DatabaseKey};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -35,7 +35,7 @@ pub fn main() -> Result<()> {
 
     let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
 
-    let db = Database::open(&mut source, Key { password, keyfile })?;
+    let db = Database::open(&mut source, DatabaseKey { password, keyfile })?;
 
     println!("{:#?}", db);
 

--- a/src/bin/kp-show-db.rs
+++ b/src/bin/kp-show-db.rs
@@ -5,7 +5,7 @@ use std::io::Read;
 use anyhow::Result;
 use clap::Parser;
 
-use keepass::Database;
+use keepass::{Database, Key};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -33,11 +33,9 @@ pub fn main() -> Result<()> {
         Some(&password[..])
     };
 
-    let db = Database::open(
-        &mut source,
-        password,
-        keyfile.as_mut().map(|kf| kf as &mut dyn Read),
-    )?;
+    let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
+
+    let db = Database::open(&mut source, Key { password, keyfile })?;
 
     println!("{:#?}", db);
 

--- a/src/bin/kp-show-otp.rs
+++ b/src/bin/kp-show-otp.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 
 use anyhow::Result;
 use clap::Parser;
-use keepass::NodeRef;
+use keepass::{db::NodeRef, Database, Key};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -36,11 +36,9 @@ pub fn main() -> Result<()> {
         Some(&password[..])
     };
 
-    let db = keepass::Database::open(
-        &mut source,
-        password,
-        keyfile.as_mut().map(|kf| kf as &mut dyn Read),
-    )?;
+    let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
+
+    let db = Database::open(&mut source, Key { password, keyfile })?;
 
     if let Some(NodeRef::Entry(e)) = db.root.get(&[&args.entry]) {
         let totp = e.get_otp().unwrap();

--- a/src/bin/kp-show-otp.rs
+++ b/src/bin/kp-show-otp.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 
 use anyhow::Result;
 use clap::Parser;
-use keepass::{db::NodeRef, Database, Key};
+use keepass::{db::NodeRef, Database, DatabaseKey};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -38,7 +38,7 @@ pub fn main() -> Result<()> {
 
     let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
 
-    let db = Database::open(&mut source, Key { password, keyfile })?;
+    let db = Database::open(&mut source, DatabaseKey { password, keyfile })?;
 
     if let Some(NodeRef::Entry(e)) = db.root.get(&[&args.entry]) {
         let totp = e.get_otp().unwrap();

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,16 +1,16 @@
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use flate2::Compression;
+use flate2::Compression as Flate2Compression;
 use std::io::{Read, Write};
 
-pub trait Decompress {
+pub trait Compression {
     fn compress(&self, in_buffer: &[u8]) -> Result<Vec<u8>, std::io::Error>;
     fn decompress(&self, in_buffer: &[u8]) -> Result<Vec<u8>, std::io::Error>;
 }
 
 pub struct NoCompression;
 
-impl Decompress for NoCompression {
+impl Compression for NoCompression {
     fn compress(&self, in_buffer: &[u8]) -> Result<Vec<u8>, std::io::Error> {
         Ok(in_buffer.to_vec())
     }
@@ -21,10 +21,10 @@ impl Decompress for NoCompression {
 
 pub struct GZipCompression;
 
-impl Decompress for GZipCompression {
+impl Compression for GZipCompression {
     fn compress(&self, in_buffer: &[u8]) -> Result<Vec<u8>, std::io::Error> {
         let mut res = Vec::new();
-        let mut encoder = GzEncoder::new(&mut res, Compression::default());
+        let mut encoder = GzEncoder::new(&mut res, Flate2Compression::default());
         encoder.write_all(in_buffer)?;
         encoder.flush()?;
         encoder.finish()?;

--- a/src/crypt/mod.rs
+++ b/src/crypt/mod.rs
@@ -1,36 +1,15 @@
-use cipher::{
-    block_padding::UnpadError,
-    generic_array::{
-        typenum::{U32, U64},
-        GenericArray,
-    },
-    inout::PadError,
-    InvalidLength,
+use cipher::generic_array::{
+    typenum::{U32, U64},
+    GenericArray,
 };
-
-use thiserror::Error;
 
 use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256, Sha512};
 
+use crate::error::CryptographyError;
+
 pub(crate) mod ciphers;
 pub(crate) mod kdf;
-
-/// Errors while performing cryptographic operations
-#[derive(Debug, Error)]
-pub enum CryptographyError {
-    #[error(transparent)]
-    InvalidLength(#[from] InvalidLength),
-
-    #[error(transparent)]
-    Unpadding(#[from] UnpadError),
-
-    #[error(transparent)]
-    Padding(#[from] PadError),
-
-    #[error(transparent)]
-    Argon2(#[from] argon2::Error),
-}
 
 pub(crate) fn calculate_hmac(
     elements: &[&[u8]],

--- a/src/crypt/mod.rs
+++ b/src/crypt/mod.rs
@@ -16,6 +16,7 @@ use sha2::{Digest, Sha256, Sha512};
 pub(crate) mod ciphers;
 pub(crate) mod kdf;
 
+/// Errors while performing cryptographic operations
 #[derive(Debug, Error)]
 pub enum CryptographyError {
     #[error(transparent)]

--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use secstr::SecStr;
 use uuid::Uuid;
 
-use crate::{db::Times, CustomData};
+use crate::db::{CustomData, Times};
 
 #[cfg(feature = "totp")]
-use crate::otp::{TOTPError, TOTP};
+use crate::db::otp::{TOTPError, TOTP};
 
 /// A database entry containing several key-value fields.
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
@@ -114,6 +114,7 @@ impl<'a> Entry {
     }
 }
 
+/// A value that can be a raw string, byte array, or protected memory region
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Value {
     Bytes(Vec<u8>),
@@ -162,6 +163,7 @@ pub struct AutoTypeAssociation {
     pub sequence: Option<String>,
 }
 
+/// An entry's history
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct History {

--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -63,11 +63,11 @@ impl Group {
 
     /// Recursively get a Group or Entry reference by specifying a path relative to the current Group
     /// ```
-    /// use keepass::{Database, NodeRef};
+    /// use keepass::{Database, Key, db::NodeRef};
     /// use std::{fs::File, path::Path};
     ///
     /// let path = Path::new("tests/resources/test_db_with_password.kdbx");
-    /// let db = Database::open(&mut File::open(path).unwrap(), Some("demopass"), None).unwrap();
+    /// let db = Database::open(&mut File::open(path).unwrap(), Key::with_password("demopass")).unwrap();
     ///
     /// if let Some(NodeRef::Entry(e)) = db.root.get(&["General", "Sample Entry #2"]) {
     ///     println!("User: {}", e.get_username().unwrap());
@@ -83,7 +83,7 @@ impl Group {
                     Node::Group(_) => None,
                     Node::Entry(e) => {
                         e.get_title()
-                            .and_then(|t| if t == head { Some(n.to_ref()) } else { None })
+                            .and_then(|t| if t == head { Some(n.as_ref()) } else { None })
                     }
                 })
             } else {
@@ -114,7 +114,7 @@ impl Group {
                         Node::Group(g) => g.name == head,
                         Node::Entry(e) => e.get_title().map(|t| t == head).unwrap_or(false),
                     })
-                    .map(|t| t.to_ref_mut())
+                    .map(|t| t.as_mut())
                     .next()
             } else {
                 let head = path[0];

--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -63,11 +63,14 @@ impl Group {
 
     /// Recursively get a Group or Entry reference by specifying a path relative to the current Group
     /// ```
-    /// use keepass::{Database, Key, db::NodeRef};
+    /// use keepass::{Database, DatabaseKey, db::NodeRef};
     /// use std::{fs::File, path::Path};
     ///
     /// let path = Path::new("tests/resources/test_db_with_password.kdbx");
-    /// let db = Database::open(&mut File::open(path).unwrap(), Key::with_password("demopass")).unwrap();
+    /// let db = Database::open(
+    ///     &mut File::open(path).unwrap(),
+    ///     DatabaseKey::with_password("demopass")
+    /// ).unwrap();
     ///
     /// if let Some(NodeRef::Entry(e)) = db.root.get(&["General", "Sample Entry #2"]) {
     ///     println!("User: {}", e.get_username().unwrap());

--- a/src/db/meta.rs
+++ b/src/db/meta.rs
@@ -61,9 +61,10 @@ pub struct Meta {
     /// last time the group containing entry templates was changed
     pub entry_templates_group_changed: Option<NaiveDateTime>,
 
-    /// last selected group UUID
+    /// UUID of the last selected group
     pub last_selected_group: Option<String>,
 
+    /// UUID of the last top-visible group
     pub last_top_visible_group: Option<String>,
 
     /// Maximum number of items of history to keep

--- a/src/db/meta.rs
+++ b/src/db/meta.rs
@@ -27,8 +27,10 @@ pub struct Meta {
     /// time the default username was last changed
     pub default_username_changed: Option<NaiveDateTime>,
 
+    /// number of days of maintenance history to keep
     pub maintenance_history_days: Option<usize>,
 
+    /// color code for the database
     pub color: Option<String>,
 
     /// time the master key was last changed
@@ -38,65 +40,106 @@ pub struct Meta {
 
     pub master_key_change_force: Option<isize>,
 
+    /// memory protection settings
     pub memory_protection: Option<MemoryProtection>,
 
+    /// custom icons
     pub custom_icons: CustomIcons,
 
+    /// whether the recycle bin is enabled
     pub recyclebin_enabled: Option<bool>,
 
     /// A UUID for the recycle bin group
     pub recyclebin_uuid: Option<String>,
 
+    /// last time the recycle bin was changed
     pub recyclebin_changed: Option<NaiveDateTime>,
 
+    /// UUID of the group containing entry templates
     pub entry_templates_group: Option<String>,
 
+    /// last time the group containing entry templates was changed
     pub entry_templates_group_changed: Option<NaiveDateTime>,
 
+    /// last selected group UUID
     pub last_selected_group: Option<String>,
 
     pub last_top_visible_group: Option<String>,
 
+    /// Maximum number of items of history to keep
     pub history_max_items: Option<usize>,
 
+    /// Maximum size of the history to keep
     pub history_max_size: Option<usize>,
 
+    /// Last time the settings were changed
     pub settings_changed: Option<NaiveDateTime>,
 
+    /// Binary attachments in the Metadata header
     pub binaries: BinaryAttachments,
 
+    /// Additional custom data fields
     pub custom_data: CustomData,
 }
 
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
+/// Database memory protection settings
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct MemoryProtection {
+    /// Whether titles should be protected
     pub protect_title: bool,
+
+    /// Whether user names should be protected
     pub protect_username: bool,
+
+    /// Whether passwords should be protected
     pub protect_password: bool,
+
+    /// Whether URLs should be protected
     pub protect_url: bool,
+
+    /// Whether notes should be protected
     pub protect_notes: bool,
 }
 
+impl Default for MemoryProtection {
+    fn default() -> Self {
+        Self {
+            protect_title: false,
+            protect_username: false,
+            protect_password: true,
+            protect_url: false,
+            protect_notes: false,
+        }
+    }
+}
+
+/// Collection of custom icons
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct CustomIcons {
     pub icons: Vec<Icon>,
 }
 
+/// A custom icon
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct Icon {
+    /// UUID, to reference the icon
     pub uuid: String,
+
+    /// Image data
     pub data: Vec<u8>,
 }
 
+/// Collection of binary attachments in the metadata of an XML database
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct BinaryAttachments {
     pub binaries: Vec<BinaryAttachment>,
 }
 
+/// Binary attachment in the metadata of a XML database
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct BinaryAttachment {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,5 @@
+//! Types for representing data contained in a KeePass database
+
 pub(crate) mod entry;
 pub(crate) mod group;
 pub(crate) mod meta;
@@ -9,34 +11,27 @@ pub(crate) mod otp;
 use std::collections::HashMap;
 
 use chrono::NaiveDateTime;
-use thiserror::Error;
 
 pub use crate::db::{
-    entry::{AutoType, AutoTypeAssociation, Entry, Value},
+    entry::{AutoType, AutoTypeAssociation, Entry, History, Value},
     group::Group,
-    meta::{BinaryAttachment, Meta},
+    meta::{BinaryAttachment, BinaryAttachments, Meta},
     node::{Node, NodeIter, NodeRef, NodeRefMut},
 };
 
 #[cfg(feature = "totp")]
-pub use crate::otp::{TOTPError, TOTP};
+pub use crate::db::otp::{TOTPAlgorithm, TOTP};
 
 use crate::{
-    config::{
-        Compression, CompressionError, InnerCipherSuite, InnerCipherSuiteError, KdfSettings,
-        KdfSettingsError, OuterCipherSuite, OuterCipherSuiteError,
-    },
-    crypt::{calculate_sha256, CryptographyError},
+    config::{CompressionConfig, InnerCipherConfig, KdfConfig, OuterCipherConfig},
+    error::{DatabaseIntegrityError, DatabaseOpenError},
     format::{
         kdb::parse_kdb,
         kdbx3::{decrypt_kdbx3, parse_kdbx3},
         kdbx4::{decrypt_kdbx4, parse_kdbx4},
         DatabaseVersion, KDBX4_CURRENT_MINOR_VERSION,
     },
-    hmac_block_stream::BlockStreamError,
-    keyfile::KeyfileError,
-    variant_dictionary::VariantDictionaryError,
-    xml_db::parse::XmlParseError,
+    key::Key,
 };
 
 /// A decrypted KeePass database
@@ -56,230 +51,35 @@ pub struct Database {
     pub meta: Meta,
 }
 
-#[derive(Debug, Error)]
-pub enum DatabaseKeyError {
-    #[error("Incorrect key")]
-    IncorrectKey,
-
-    #[error(transparent)]
-    Cryptography(#[from] CryptographyError),
-
-    #[error(transparent)]
-    Keyfile(#[from] KeyfileError),
-}
-
-#[derive(Debug, Error)]
-pub enum DatabaseOpenError {
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-
-    #[error(transparent)]
-    Key(#[from] DatabaseKeyError),
-
-    #[error(transparent)]
-    DatabaseIntegrity(#[from] DatabaseIntegrityError),
-
-    #[error("Opening this database version is not supported")]
-    UnsupportedVersion,
-}
-
-#[derive(Debug, Error)]
-pub enum DatabaseIntegrityError {
-    #[error("Invalid KDBX identifier")]
-    InvalidKDBXIdentifier,
-
-    #[error(
-        "Invalid KDBX version: {}.{}.{}",
-        version,
-        file_major_version,
-        file_minor_version
-    )]
-    InvalidKDBXVersion {
-        version: u32,
-        file_major_version: u32,
-        file_minor_version: u32,
-    },
-
-    #[error("Invalid header size: {}", size)]
-    InvalidFixedHeader { size: usize },
-
-    #[error(
-        "Invalid field length for type {}: {} (expected {})",
-        field_type,
-        field_size,
-        expected_field_size
-    )]
-    InvalidKDBFieldLength {
-        field_type: u16,
-        field_size: u32,
-        expected_field_size: u32,
-    },
-
-    #[error("Missing group level")]
-    MissingKDBGroupLevel,
-
-    #[error(
-        "Invalid group level {} (current level {})",
-        group_level,
-        current_level
-    )]
-    InvalidKDBGroupLevel {
-        group_level: u16,
-        current_level: u16,
-    },
-
-    #[error("Missing group ID")]
-    MissingKDBGroupId,
-
-    #[error("Invalid group ID {}", group_id)]
-    InvalidKDBGroupId { group_id: u32 },
-
-    #[error("Invalid group field type: {}", field_type)]
-    InvalidKDBGroupFieldType { field_type: u16 },
-
-    #[error("Invalid entry field type: {}", field_type)]
-    InvalidKDBEntryFieldType { field_type: u16 },
-
-    #[error("Incomplete group")]
-    IncompleteKDBGroup,
-
-    #[error("Incomplete entry")]
-    IncompleteKDBEntry,
-
-    #[error("Invalid fixed cipher ID: {}", cid)]
-    InvalidFixedCipherID { cid: u32 },
-
-    #[error("Header hash masmatch")]
-    HeaderHashMismatch,
-
-    #[error("Invalid outer header entry: {}", entry_type)]
-    InvalidOuterHeaderEntry { entry_type: u8 },
-
-    #[error("Incomplete outer header: Missing {}", missing_field)]
-    IncompleteOuterHeader { missing_field: String },
-
-    #[error("Invalid inner header entry: {}", entry_type)]
-    InvalidInnerHeaderEntry { entry_type: u8 },
-
-    #[error("Incomplete outer header: Missing {}", missing_field)]
-    IncompleteInnerHeader { missing_field: String },
-
-    #[error(transparent)]
-    Cryptography(#[from] CryptographyError),
-
-    #[error(transparent)]
-    Xml(#[from] XmlParseError),
-
-    #[error(transparent)]
-    OuterCipher(#[from] OuterCipherSuiteError),
-
-    #[error(transparent)]
-    InnerCipher(#[from] InnerCipherSuiteError),
-
-    #[error(transparent)]
-    Compression(#[from] CompressionError),
-
-    #[error(transparent)]
-    BlockStream(#[from] BlockStreamError),
-
-    #[error(transparent)]
-    VariantDictionary(#[from] VariantDictionaryError),
-
-    #[error(transparent)]
-    KdfSettings(#[from] KdfSettingsError),
-
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-}
-
-#[derive(Debug, Error)]
-pub enum DatabaseSaveError {
-    #[error("Saving this database version is not supported")]
-    UnsupportedVersion,
-
-    #[error("Error while generating XML")]
-    Xml(#[from] xml::writer::Error),
-
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-
-    #[error(transparent)]
-    Key(#[from] DatabaseKeyError),
-
-    #[error(transparent)]
-    Cryptography(#[from] CryptographyError),
-
-    #[error(transparent)]
-    Random(#[from] getrandom::Error),
-}
-
-impl From<CryptographyError> for DatabaseOpenError {
-    fn from(e: CryptographyError) -> Self {
-        DatabaseIntegrityError::from(e).into()
-    }
-}
-
-impl From<BlockStreamError> for DatabaseOpenError {
-    fn from(e: BlockStreamError) -> Self {
-        DatabaseIntegrityError::from(e).into()
-    }
-}
-
-impl From<XmlParseError> for DatabaseOpenError {
-    fn from(e: XmlParseError) -> Self {
-        DatabaseIntegrityError::from(e).into()
-    }
-}
-
-impl From<InnerCipherSuiteError> for DatabaseOpenError {
-    fn from(e: InnerCipherSuiteError) -> Self {
-        DatabaseIntegrityError::from(e).into()
-    }
-}
-
-impl From<OuterCipherSuiteError> for DatabaseOpenError {
-    fn from(e: OuterCipherSuiteError) -> Self {
-        DatabaseIntegrityError::from(e).into()
-    }
-}
-
-impl From<KdfSettingsError> for DatabaseOpenError {
-    fn from(e: KdfSettingsError) -> Self {
-        DatabaseIntegrityError::from(e).into()
-    }
-}
-
-impl From<VariantDictionaryError> for DatabaseOpenError {
-    fn from(e: VariantDictionaryError) -> Self {
-        DatabaseIntegrityError::from(e).into()
-    }
-}
-
-impl From<CompressionError> for DatabaseOpenError {
-    fn from(e: CompressionError) -> Self {
-        DatabaseIntegrityError::from(e).into()
-    }
-}
-
+/// Settings for how a database is stored on disk
 #[derive(Debug)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct DatabaseSettings {
+    /// Version of the outer database file
     pub version: DatabaseVersion,
 
-    pub outer_cipher_suite: OuterCipherSuite,
-    pub compression: Compression,
-    pub inner_cipher_suite: InnerCipherSuite,
-    pub kdf_settings: KdfSettings,
+    /// What encryption to use for the outer encryption
+    pub outer_cipher_suite: OuterCipherConfig,
+
+    /// What algorithm to use to compress the inner data
+    pub compression: CompressionConfig,
+
+    /// What encryption to use for protected fields inside the database
+    pub inner_cipher_suite: InnerCipherConfig,
+
+    /// Settings for the Key Derivation Function (KDF)
+    pub kdf_settings: KdfConfig,
 }
 
+/// Sensible default database settings for new databases
 impl Default for DatabaseSettings {
     fn default() -> Self {
         Self {
             version: DatabaseVersion::KDB4(KDBX4_CURRENT_MINOR_VERSION),
-            outer_cipher_suite: OuterCipherSuite::AES256,
-            compression: Compression::GZip,
-            inner_cipher_suite: InnerCipherSuite::ChaCha20,
-            kdf_settings: KdfSettings::Argon2 {
+            outer_cipher_suite: OuterCipherConfig::AES256,
+            compression: CompressionConfig::GZip,
+            inner_cipher_suite: InnerCipherConfig::ChaCha20,
+            kdf_settings: KdfConfig::Argon2 {
                 iterations: 50,
                 memory: 1024 * 1024,
                 parallelism: 4,
@@ -291,12 +91,8 @@ impl Default for DatabaseSettings {
 
 impl Database {
     /// Parse a database from a std::io::Read
-    pub fn open(
-        source: &mut dyn std::io::Read,
-        password: Option<&str>,
-        keyfile: Option<&mut dyn std::io::Read>,
-    ) -> Result<Database, DatabaseOpenError> {
-        let key_elements = Database::get_key_elements(password, keyfile)?;
+    pub fn open(source: &mut dyn std::io::Read, key: Key) -> Result<Database, DatabaseOpenError> {
+        let key_elements = key.get_key_elements()?;
 
         let mut data = Vec::new();
         source.read_to_end(&mut data)?;
@@ -316,12 +112,12 @@ impl Database {
     pub fn save(
         &self,
         destination: &mut dyn std::io::Write,
-        password: Option<&str>,
-        keyfile: Option<&mut dyn std::io::Read>,
-    ) -> Result<(), DatabaseSaveError> {
+        key: Key,
+    ) -> Result<(), crate::error::DatabaseSaveError> {
+        use crate::error::DatabaseSaveError;
         use crate::format::kdbx4::dump_kdbx4;
 
-        let key_elements = Database::get_key_elements(password, keyfile)?;
+        let key_elements = key.get_key_elements()?;
 
         match self.settings.version {
             DatabaseVersion::KDB(_) => Err(DatabaseSaveError::UnsupportedVersion.into()),
@@ -331,45 +127,9 @@ impl Database {
         }
     }
 
-    #[cfg(feature = "save_kdbx4")]
-    pub fn dump(
-        &self,
-        password: Option<&str>,
-        keyfile: Option<&mut dyn std::io::Read>,
-    ) -> Result<Vec<u8>, DatabaseSaveError> {
-        let mut data = Vec::new();
-        self.save(&mut data, password, keyfile)?;
-        Ok(data)
-    }
-
-    pub fn get_key_elements(
-        password: Option<&str>,
-        keyfile: Option<&mut dyn std::io::Read>,
-    ) -> Result<Vec<Vec<u8>>, DatabaseKeyError> {
-        let mut key_elements: Vec<Vec<u8>> = Vec::new();
-
-        if let Some(p) = password {
-            key_elements.push(calculate_sha256(&[p.as_bytes()])?.as_slice().to_vec());
-        }
-
-        if let Some(f) = keyfile {
-            key_elements.push(crate::keyfile::parse(f)?);
-        }
-
-        if key_elements.is_empty() {
-            return Err(DatabaseKeyError::IncorrectKey);
-        }
-
-        Ok(key_elements)
-    }
-
     /// Helper function to load a database into its internal XML chunks
-    pub fn get_xml(
-        source: &mut dyn std::io::Read,
-        password: Option<&str>,
-        keyfile: Option<&mut dyn std::io::Read>,
-    ) -> Result<Vec<u8>, DatabaseOpenError> {
-        let key_elements = Database::get_key_elements(password, keyfile)?;
+    pub fn get_xml(source: &mut dyn std::io::Read, key: Key) -> Result<Vec<u8>, DatabaseOpenError> {
+        let key_elements = key.get_key_elements()?;
 
         let mut data = Vec::new();
         source.read_to_end(&mut data)?;
@@ -386,7 +146,7 @@ impl Database {
         Ok(data)
     }
 
-    /// Get the version of a database.
+    /// Get the version of a database without loading it
     pub fn get_version(
         source: &mut dyn std::io::Read,
     ) -> Result<DatabaseVersion, DatabaseIntegrityError> {
@@ -396,6 +156,7 @@ impl Database {
         DatabaseVersion::parse(data.as_ref())
     }
 
+    /// Create a new, empty database
     pub fn new(settings: DatabaseSettings) -> Database {
         Self {
             settings,
@@ -406,6 +167,7 @@ impl Database {
     }
 }
 
+/// Timestamps for a Group or Entry
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct Times {
@@ -428,12 +190,14 @@ impl Times {
     }
 }
 
+/// Collection of custom data fields for an entry or metadata
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct CustomData {
     pub items: Vec<CustomDataItem>,
 }
 
+/// Custom data field for an entry or metadata
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct CustomDataItem {
@@ -442,6 +206,7 @@ pub struct CustomDataItem {
     pub last_modification_time: Option<NaiveDateTime>,
 }
 
+/// Binary attachments stored in a database inner header
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct HeaderAttachment {

--- a/src/db/node.rs
+++ b/src/db/node.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 
 use crate::db::{entry::Entry, group::Group};
 
+/// An owned node in the database tree structure which can either be an Entry or Group
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub enum Node {
@@ -10,15 +11,16 @@ pub enum Node {
 }
 
 impl Node {
-    pub fn to_ref<'a>(&'a self) -> NodeRef<'a> {
+    pub fn as_ref<'a>(&'a self) -> NodeRef<'a> {
         self.into()
     }
 
-    pub fn to_ref_mut<'a>(&'a mut self) -> NodeRefMut<'a> {
+    pub fn as_mut<'a>(&'a mut self) -> NodeRefMut<'a> {
         self.into()
     }
 }
 
+/// A shared reference to a node in the database tree structure which can either point to an Entry or a Group
 #[derive(Debug, Eq, PartialEq)]
 pub enum NodeRef<'a> {
     Group(&'a Group),
@@ -34,6 +36,7 @@ impl<'a> std::convert::From<&'a Node> for NodeRef<'a> {
     }
 }
 
+/// An exclusive mutable reference to a node in the database tree structure which can either point to an Entry or a Group
 #[derive(Debug, Eq, PartialEq)]
 pub enum NodeRefMut<'a> {
     Group(&'a mut Group),
@@ -49,7 +52,7 @@ impl<'a> std::convert::From<&'a mut Node> for NodeRefMut<'a> {
     }
 }
 
-/// An iterator over Groups and Entries
+/// An iterator over Group and Entry references
 pub struct NodeIter<'a> {
     queue: VecDeque<NodeRef<'a>>,
 }

--- a/src/db/otp.rs
+++ b/src/db/otp.rs
@@ -7,6 +7,7 @@ use url::Url;
 const DEFAULT_PERIOD: u64 = 30;
 const DEFAULT_DIGITS: u32 = 8;
 
+/// Choices of hash algorithm for TOTP
 #[derive(Debug, PartialEq, Eq)]
 pub enum TOTPAlgorithm {
     Sha1,
@@ -27,6 +28,7 @@ impl std::str::FromStr for TOTPAlgorithm {
     }
 }
 
+/// Time-based one time password settings
 #[derive(Debug, PartialEq, Eq)]
 pub struct TOTP {
     label: String,
@@ -37,6 +39,7 @@ pub struct TOTP {
     algorithm: TOTPAlgorithm,
 }
 
+/// A generated one time password
 pub struct OTPCode {
     pub code: String,
     pub valid_for: Duration,
@@ -55,6 +58,7 @@ impl std::fmt::Display for OTPCode {
     }
 }
 
+/// Errors while processing a TOTP specification
 #[derive(Debug, Error)]
 pub enum TOTPError {
     #[error(transparent)]
@@ -162,15 +166,18 @@ impl TOTP {
 
 #[cfg(test)]
 mod kdbx4_otp_tests {
-    use super::{TOTPError, TOTP};
-    use crate::*;
+    use super::{TOTPAlgorithm, TOTPError, TOTP};
+    use crate::{
+        db::{Database, NodeRef},
+        key::Key,
+    };
     use std::{fs::File, path::Path};
 
     #[test]
     fn kdbx4_entry() -> Result<(), Box<dyn std::error::Error>> {
         // KDBX4 database format Base64 encodes ExpiryTime (and all other XML timestamps)
         let path = Path::new("tests/resources/test_db_kdbx4_with_totp_entry.kdbx");
-        let db = Database::open(&mut File::open(path)?, Some("test"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("test"))?;
 
         let otp_str = "otpauth://totp/KeePassXC:none?secret=JBSWY3DPEHPK3PXP&period=30&digits=6&issuer=KeePassXC";
 
@@ -195,7 +202,7 @@ mod kdbx4_otp_tests {
             issuer: "KeePassXC".to_string(),
             period: 30,
             digits: 6,
-            algorithm: otp::TOTPAlgorithm::Sha1,
+            algorithm: TOTPAlgorithm::Sha1,
         };
 
         assert_eq!(otp_str.parse::<TOTP>()?, expected);
@@ -213,7 +220,7 @@ mod kdbx4_otp_tests {
             issuer: "sha512 totp".to_string(),
             period: 30,
             digits: 6,
-            algorithm: otp::TOTPAlgorithm::Sha512,
+            algorithm: TOTPAlgorithm::Sha512,
         };
 
         assert_eq!(otp_str.parse::<TOTP>()?, expected);
@@ -229,7 +236,7 @@ mod kdbx4_otp_tests {
             issuer: "KeePassXC".to_string(),
             period: 30,
             digits: 6,
-            algorithm: otp::TOTPAlgorithm::Sha1,
+            algorithm: TOTPAlgorithm::Sha1,
         };
 
         assert_eq!(totp.value_at(1234).code, "806863")

--- a/src/db/otp.rs
+++ b/src/db/otp.rs
@@ -169,7 +169,7 @@ mod kdbx4_otp_tests {
     use super::{TOTPAlgorithm, TOTPError, TOTP};
     use crate::{
         db::{Database, NodeRef},
-        key::Key,
+        key::DatabaseKey,
     };
     use std::{fs::File, path::Path};
 
@@ -177,7 +177,7 @@ mod kdbx4_otp_tests {
     fn kdbx4_entry() -> Result<(), Box<dyn std::error::Error>> {
         // KDBX4 database format Base64 encodes ExpiryTime (and all other XML timestamps)
         let path = Path::new("tests/resources/test_db_kdbx4_with_totp_entry.kdbx");
-        let db = Database::open(&mut File::open(path)?, Key::with_password("test"))?;
+        let db = Database::open(&mut File::open(path)?, DatabaseKey::with_password("test"))?;
 
         let otp_str = "otpauth://totp/KeePassXC:none?secret=JBSWY3DPEHPK3PXP&period=30&digits=6&issuer=KeePassXC";
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,232 @@
+//! Error types that this crate can return
+
+use thiserror::Error;
+
+pub use crate::{
+    config::{
+        CompressionConfigError, InnerCipherConfigError, KdfConfigError, OuterCipherConfigError,
+    },
+    crypt::CryptographyError,
+    hmac_block_stream::BlockStreamError,
+    key::DatabaseKeyError,
+    variant_dictionary::VariantDictionaryError,
+    xml_db::parse::XmlParseError,
+};
+
+#[cfg(feature = "totp")]
+pub use crate::db::otp::TOTPError;
+
+/// Errors upon reading a Database
+#[derive(Debug, Error)]
+pub enum DatabaseOpenError {
+    /// An I/O error has occurred while reading the database
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// An error with the database's key has occurred
+    #[error(transparent)]
+    Key(#[from] DatabaseKeyError),
+
+    /// The database is corrupted
+    #[error(transparent)]
+    DatabaseIntegrity(#[from] DatabaseIntegrityError),
+
+    /// The database version cannot be read by this library
+    #[error("Opening this database version is not supported")]
+    UnsupportedVersion,
+}
+
+/// Errors stemming from corrupted databases
+#[derive(Debug, Error)]
+pub enum DatabaseIntegrityError {
+    /// The database does not have a valid KDBX identifier
+    #[error("Invalid KDBX identifier")]
+    InvalidKDBXIdentifier,
+
+    /// The version of the KDBX file is invalid
+    #[error(
+        "Invalid KDBX version: {}.{}.{}",
+        version,
+        file_major_version,
+        file_minor_version
+    )]
+    InvalidKDBXVersion {
+        version: u32,
+        file_major_version: u32,
+        file_minor_version: u32,
+    },
+
+    /// The fixed header has an invalid size
+    #[error("Invalid header size: {}", size)]
+    InvalidFixedHeader { size: usize },
+
+    #[error(
+        "Invalid field length for type {}: {} (expected {})",
+        field_type,
+        field_size,
+        expected_field_size
+    )]
+    InvalidKDBFieldLength {
+        field_type: u16,
+        field_size: u32,
+        expected_field_size: u32,
+    },
+
+    #[error("Missing group level")]
+    MissingKDBGroupLevel,
+
+    #[error(
+        "Invalid group level {} (current level {})",
+        group_level,
+        current_level
+    )]
+    InvalidKDBGroupLevel {
+        group_level: u16,
+        current_level: u16,
+    },
+
+    #[error("Missing group ID")]
+    MissingKDBGroupId,
+
+    #[error("Invalid group ID {}", group_id)]
+    InvalidKDBGroupId { group_id: u32 },
+
+    #[error("Invalid group field type: {}", field_type)]
+    InvalidKDBGroupFieldType { field_type: u16 },
+
+    #[error("Invalid entry field type: {}", field_type)]
+    InvalidKDBEntryFieldType { field_type: u16 },
+
+    #[error("Incomplete group")]
+    IncompleteKDBGroup,
+
+    #[error("Incomplete entry")]
+    IncompleteKDBEntry,
+
+    #[error("Invalid fixed cipher ID: {}", cid)]
+    InvalidFixedCipherID { cid: u32 },
+
+    #[error("Header hash masmatch")]
+    HeaderHashMismatch,
+
+    #[error("Invalid outer header entry: {}", entry_type)]
+    InvalidOuterHeaderEntry { entry_type: u8 },
+
+    #[error("Incomplete outer header: Missing {}", missing_field)]
+    IncompleteOuterHeader { missing_field: String },
+
+    #[error("Invalid inner header entry: {}", entry_type)]
+    InvalidInnerHeaderEntry { entry_type: u8 },
+
+    #[error("Incomplete outer header: Missing {}", missing_field)]
+    IncompleteInnerHeader { missing_field: String },
+
+    #[error(transparent)]
+    Cryptography(#[from] CryptographyError),
+
+    #[error(transparent)]
+    Xml(#[from] XmlParseError),
+
+    #[error(transparent)]
+    OuterCipher(#[from] OuterCipherConfigError),
+
+    #[error(transparent)]
+    InnerCipher(#[from] InnerCipherConfigError),
+
+    #[error(transparent)]
+    Compression(#[from] CompressionConfigError),
+
+    #[error(transparent)]
+    BlockStream(#[from] BlockStreamError),
+
+    #[error(transparent)]
+    VariantDictionary(#[from] VariantDictionaryError),
+
+    #[error(transparent)]
+    KdfSettings(#[from] KdfConfigError),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// Errors occurring when saving a Database
+#[derive(Debug, Error)]
+pub enum DatabaseSaveError {
+    /// The current database version cannot be saved by this library
+    #[error("Saving this database version is not supported")]
+    UnsupportedVersion,
+
+    /// Error while writing out the inner XML database
+    #[error("Error while generating XML")]
+    Xml(#[from] xml::writer::Error),
+
+    /// General I/O issues while writing the database
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// An error with the key occurred while writing the database
+    #[error(transparent)]
+    Key(#[from] DatabaseKeyError),
+
+    /// A cryptography error occurred while writing the database
+    #[error(transparent)]
+    Cryptography(#[from] CryptographyError),
+
+    /// An error getting randomness for keys occurred
+    #[error(transparent)]
+    Random(#[from] getrandom::Error),
+}
+
+// move error type conversions to a module and exclude them from coverage counting.
+#[cfg(not(tarpaulin_include))]
+mod conversions {
+    use super::*;
+
+    impl From<CryptographyError> for DatabaseOpenError {
+        fn from(e: CryptographyError) -> Self {
+            DatabaseIntegrityError::from(e).into()
+        }
+    }
+
+    impl From<BlockStreamError> for DatabaseOpenError {
+        fn from(e: BlockStreamError) -> Self {
+            DatabaseIntegrityError::from(e).into()
+        }
+    }
+
+    impl From<XmlParseError> for DatabaseOpenError {
+        fn from(e: XmlParseError) -> Self {
+            DatabaseIntegrityError::from(e).into()
+        }
+    }
+
+    impl From<InnerCipherConfigError> for DatabaseOpenError {
+        fn from(e: InnerCipherConfigError) -> Self {
+            DatabaseIntegrityError::from(e).into()
+        }
+    }
+
+    impl From<OuterCipherConfigError> for DatabaseOpenError {
+        fn from(e: OuterCipherConfigError) -> Self {
+            DatabaseIntegrityError::from(e).into()
+        }
+    }
+
+    impl From<KdfConfigError> for DatabaseOpenError {
+        fn from(e: KdfConfigError) -> Self {
+            DatabaseIntegrityError::from(e).into()
+        }
+    }
+
+    impl From<VariantDictionaryError> for DatabaseOpenError {
+        fn from(e: VariantDictionaryError) -> Self {
+            DatabaseIntegrityError::from(e).into()
+        }
+    }
+
+    impl From<CompressionConfigError> for DatabaseOpenError {
+        fn from(e: CompressionConfigError) -> Self {
+            DatabaseIntegrityError::from(e).into()
+        }
+    }
+}

--- a/src/format/kdbx3.rs
+++ b/src/format/kdbx3.rs
@@ -1,10 +1,9 @@
 use crate::{
-    config::{CompressionConfig, InnerCipherConfig, KdfConfig, OuterCipherConfig},
+    config::{CompressionConfig, DatabaseConfig, InnerCipherConfig, KdfConfig, OuterCipherConfig},
     crypt::{calculate_sha256, ciphers::Cipher},
-    db::{Database, DatabaseSettings},
-    error::{DatabaseIntegrityError, DatabaseKeyError, DatabaseOpenError},
+    db::Database,
+    error::{BlockStreamError, DatabaseIntegrityError, DatabaseKeyError, DatabaseOpenError},
     format::DatabaseVersion,
-    hmac_block_stream::BlockStreamError,
 };
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -19,7 +18,7 @@ struct KDBX3Header {
     master_seed: Vec<u8>,
 
     transform_seed: Vec<u8>,
-    kdf_settings: KdfConfig,
+    kdf_config: KdfConfig,
 
     outer_iv: Vec<u8>,
     protected_stream_key: Vec<u8>,
@@ -142,7 +141,7 @@ fn parse_outer_header(data: &[u8]) -> Result<KDBX3Header, DatabaseOpenError> {
     let inner_cipher = get_or_err(inner_cipher, "Inner cipher ID")?;
 
     // KDF type is always AES for KDBX3
-    let kdf_settings = KdfConfig::Aes {
+    let kdf_config = KdfConfig::Aes {
         rounds: transform_rounds,
     };
 
@@ -151,7 +150,7 @@ fn parse_outer_header(data: &[u8]) -> Result<KDBX3Header, DatabaseOpenError> {
         compression,
         master_seed,
         transform_seed,
-        kdf_settings,
+        kdf_config,
         outer_iv,
         protected_stream_key,
         stream_start,
@@ -165,14 +164,14 @@ pub(crate) fn parse_kdbx3(
     data: &[u8],
     key_elements: &[Vec<u8>],
 ) -> Result<Database, DatabaseOpenError> {
-    let (settings, mut inner_decryptor, xml) = decrypt_kdbx3(data, key_elements)?;
+    let (config, mut inner_decryptor, xml) = decrypt_kdbx3(data, key_elements)?;
 
     // Parse XML data blocks
     let database_content = crate::xml_db::parse::parse(&xml, &mut *inner_decryptor)
         .map_err(|e| DatabaseIntegrityError::from(e))?;
 
     let db = Database {
-        settings,
+        config,
         header_attachments: Vec::new(),
         root: database_content.root.group,
         meta: database_content.meta,
@@ -185,7 +184,7 @@ pub(crate) fn parse_kdbx3(
 pub(crate) fn decrypt_kdbx3(
     data: &[u8],
     key_elements: &[Vec<u8>],
-) -> Result<(DatabaseSettings, Box<dyn Cipher>, Vec<u8>), DatabaseOpenError> {
+) -> Result<(DatabaseConfig, Box<dyn Cipher>, Vec<u8>), DatabaseOpenError> {
     let version = DatabaseVersion::parse(data)?;
     let header = parse_outer_header(data)?;
 
@@ -198,18 +197,18 @@ pub(crate) fn decrypt_kdbx3(
         .get_cipher(&stream_key)
         .map_err(|e| DatabaseIntegrityError::from(e))?;
 
-    let settings = DatabaseSettings {
+    let config = DatabaseConfig {
         version,
-        outer_cipher_suite: header.outer_cipher,
-        compression: header.compression,
-        inner_cipher_suite: header.inner_cipher,
-        kdf_settings: header.kdf_settings,
+        outer_cipher_config: header.outer_cipher,
+        compression_config: header.compression,
+        inner_cipher_config: header.inner_cipher,
+        kdf_config: header.kdf_config,
     };
 
     let mut pos = header.body_start;
 
     // Turn enums into appropriate trait objects
-    let compression = settings.compression.get_compression();
+    let compression = config.compression_config.get_compression();
 
     // Rest of file after header is payload
     let payload_encrypted = &data[pos..];
@@ -219,16 +218,16 @@ pub(crate) fn decrypt_kdbx3(
     let composite_key = calculate_sha256(&key_elements)?;
 
     // transform the key
-    let transformed_key = settings
-        .kdf_settings
+    let transformed_key = config
+        .kdf_config
         .get_kdf_seeded(&header.transform_seed)
         .transform_key(&composite_key)?;
 
     let master_key = calculate_sha256(&[header.master_seed.as_ref(), &transformed_key])?;
 
     // Decrypt payload
-    let payload = settings
-        .outer_cipher_suite
+    let payload = config
+        .outer_cipher_config
         .get_cipher(&master_key, header.outer_iv.as_ref())?
         .decrypt(payload_encrypted)?;
 
@@ -279,5 +278,5 @@ pub(crate) fn decrypt_kdbx3(
 
     let xml = compression.decompress(&buf)?;
 
-    Ok((settings, inner_decryptor, xml))
+    Ok((config, inner_decryptor, xml))
 }

--- a/src/format/kdbx4/dump.rs
+++ b/src/format/kdbx4/dump.rs
@@ -4,7 +4,8 @@ use byteorder::{LittleEndian, WriteBytesExt};
 
 use crate::{
     crypt,
-    db::Database,
+    db::{Database, HeaderAttachment},
+    error::DatabaseSaveError,
     format::{
         kdbx4::{
             KDBX4InnerHeader, KDBX4OuterHeader, HEADER_COMPRESSION_ID, HEADER_ENCRYPTION_IV,
@@ -17,7 +18,6 @@ use crate::{
     hmac_block_stream,
     io::WriteLengthTaggedExt,
     variant_dictionary::VariantDictionary,
-    DatabaseSaveError, HeaderAttachment,
 };
 
 /// Dump a KeePass database using the key elements

--- a/src/format/kdbx4/dump.rs
+++ b/src/format/kdbx4/dump.rs
@@ -26,7 +26,7 @@ pub fn dump_kdbx4(
     key_elements: &[Vec<u8>],
     writer: &mut dyn Write,
 ) -> Result<(), DatabaseSaveError> {
-    if !matches!(db.settings.version, DatabaseVersion::KDB4(_)) {
+    if !matches!(db.config.version, DatabaseVersion::KDB4(_)) {
         return Err(DatabaseSaveError::UnsupportedVersion.into());
     }
 
@@ -34,23 +34,23 @@ pub fn dump_kdbx4(
     let mut master_seed = vec![0; HEADER_MASTER_SEED_SIZE];
     getrandom::getrandom(&mut master_seed)?;
 
-    let mut outer_iv = vec![0; db.settings.outer_cipher_suite.get_iv_size()];
+    let mut outer_iv = vec![0; db.config.outer_cipher_config.get_iv_size()];
     getrandom::getrandom(&mut outer_iv)?;
 
-    let mut inner_random_stream_key = vec![0; db.settings.inner_cipher_suite.get_key_size()];
+    let mut inner_random_stream_key = vec![0; db.config.inner_cipher_config.get_key_size()];
     getrandom::getrandom(&mut inner_random_stream_key)?;
 
-    let (kdf, kdf_seed) = db.settings.kdf_settings.get_kdf_and_seed()?;
+    let (kdf, kdf_seed) = db.config.kdf_config.get_kdf_and_seed()?;
 
     // dump the outer header - need to buffer so that SHA256 can be computed
     let mut header_data = Vec::new();
     KDBX4OuterHeader {
-        version: db.settings.version.clone(),
-        outer_cipher_suite: db.settings.outer_cipher_suite.clone(),
-        compression: db.settings.compression.clone(),
+        version: db.config.version.clone(),
+        outer_cipher_config: db.config.outer_cipher_config.clone(),
+        compression_config: db.config.compression_config.clone(),
         master_seed: master_seed.clone(),
         outer_iv: outer_iv.clone(),
-        kdf_settings: db.settings.kdf_settings.clone(),
+        kdf_config: db.config.kdf_config.clone(),
         kdf_seed,
     }
     .dump(&mut header_data)?;
@@ -80,14 +80,14 @@ pub fn dump_kdbx4(
 
     // Initialize inner encryptor from inner header params
     let mut inner_cipher = db
-        .settings
-        .inner_cipher_suite
+        .config
+        .inner_cipher_config
         .get_cipher(&inner_random_stream_key)?;
 
     // dump inner header into buffer
     let mut payload = Vec::new();
     KDBX4InnerHeader {
-        inner_random_stream: db.settings.inner_cipher_suite.clone(),
+        inner_random_stream: db.config.inner_cipher_config.clone(),
         inner_random_stream_key,
     }
     .dump(&db.header_attachments, &mut payload)?;
@@ -96,14 +96,14 @@ pub fn dump_kdbx4(
     crate::xml_db::dump::dump(&db, &mut *inner_cipher, &mut payload)?;
 
     let payload_compressed = db
-        .settings
-        .compression
+        .config
+        .compression_config
         .get_compression()
         .compress(&payload)?;
 
     let payload_encrypted = db
-        .settings
-        .outer_cipher_suite
+        .config
+        .outer_cipher_config
         .get_cipher(&master_key, &outer_iv)?
         .encrypt(&payload_compressed)?;
 
@@ -126,10 +126,10 @@ impl KDBX4OuterHeader {
         self.version.dump(writer)?;
 
         writer.write_u8(HEADER_OUTER_ENCRYPTION_ID)?;
-        writer.write_with_len(&self.outer_cipher_suite.dump())?;
+        writer.write_with_len(&self.outer_cipher_config.dump())?;
 
         writer.write_u8(HEADER_COMPRESSION_ID)?;
-        writer.write_with_len(&self.compression.dump())?;
+        writer.write_with_len(&self.compression_config.dump())?;
 
         writer.write_u8(HEADER_ENCRYPTION_IV)?;
         writer.write_with_len(&self.outer_iv)?;
@@ -137,7 +137,7 @@ impl KDBX4OuterHeader {
         writer.write_u8(HEADER_MASTER_SEED)?;
         writer.write_with_len(&self.master_seed)?;
 
-        let vd: VariantDictionary = self.kdf_settings.to_variant_dictionary(&self.kdf_seed);
+        let vd: VariantDictionary = self.kdf_config.to_variant_dictionary(&self.kdf_seed);
         let mut vd_buffer = Vec::new();
         vd.dump(&mut vd_buffer)?;
 

--- a/src/format/kdbx4/mod.rs
+++ b/src/format/kdbx4/mod.rs
@@ -9,34 +9,40 @@ use crate::{
 pub(crate) use crate::format::kdbx4::dump::dump_kdbx4;
 pub(crate) use crate::format::kdbx4::parse::{decrypt_kdbx4, parse_kdbx4};
 
+/// Size for a master seed in bytes
 pub const HEADER_MASTER_SEED_SIZE: usize = 32;
 
+/// Header entry denoting the end of the header
 pub const HEADER_END: u8 = 0;
+/// Header entry denoting a comment
 pub const HEADER_COMMENT: u8 = 1;
-// A UUID specifying which cipher suite
-// should be used to encrypt the payload
+/// A UUID specifying which cipher suite should be used to encrypt the payload
 pub const HEADER_OUTER_ENCRYPTION_ID: u8 = 2;
-// First byte determines compression of payload
+/// First byte determines compression of payload
 pub const HEADER_COMPRESSION_ID: u8 = 3;
-// Master seed for deriving the master key
+/// Master seed for deriving the master key
 pub const HEADER_MASTER_SEED: u8 = 4;
-// Initialization Vector for decrypting the payload
+/// Initialization Vector for decrypting the payload
 pub const HEADER_ENCRYPTION_IV: u8 = 7;
+/// Parameters for the key derivation function
 pub const HEADER_KDF_PARAMS: u8 = 11;
 
+/// Inner header entry denoting the end of the inner header
 pub const INNER_HEADER_END: u8 = 0x00;
-/// The ID of the inner header random stream
+/// Inner header entry denoting the UUID of the inner cipher
 pub const INNER_HEADER_RANDOM_STREAM_ID: u8 = 0x01;
+/// Inner header entry denoting the key of the inner cipher
 pub const INNER_HEADER_RANDOM_STREAM_KEY: u8 = 0x02;
+/// Inner header entry denoting a binary attachment
 pub const INNER_HEADER_BINARY_ATTACHMENTS: u8 = 0x03;
 
 struct KDBX4OuterHeader {
     version: DatabaseVersion,
-    outer_cipher_suite: OuterCipherConfig,
-    compression: CompressionConfig,
+    outer_cipher_config: OuterCipherConfig,
+    compression_config: CompressionConfig,
     master_seed: Vec<u8>,
     outer_iv: Vec<u8>,
-    kdf_settings: KdfConfig,
+    kdf_config: KdfConfig,
     kdf_seed: Vec<u8>,
 }
 
@@ -50,25 +56,16 @@ mod kdbx4_tests {
     use super::*;
 
     use crate::{
-        config::{CompressionConfig, InnerCipherConfig, KdfConfig, OuterCipherConfig},
-        db::{Database, DatabaseSettings, Entry, Group, HeaderAttachment, Node, Value},
+        config::{
+            CompressionConfig, DatabaseConfig, InnerCipherConfig, KdfConfig, OuterCipherConfig,
+        },
+        db::{Database, Entry, Group, HeaderAttachment, Node, Value},
         format::{kdbx4::dump::dump_kdbx4, KDBX4_CURRENT_MINOR_VERSION},
-        key::Key,
+        key::DatabaseKey,
     };
 
-    fn test_with_settings(
-        outer_cipher_suite: OuterCipherConfig,
-        compression: CompressionConfig,
-        inner_cipher_suite: InnerCipherConfig,
-        kdf_setting: KdfConfig,
-    ) {
-        let mut db = Database::new(DatabaseSettings {
-            version: DatabaseVersion::KDB4(KDBX4_CURRENT_MINOR_VERSION),
-            outer_cipher_suite,
-            compression,
-            inner_cipher_suite,
-            kdf_settings: kdf_setting,
-        });
+    fn test_with_config(config: DatabaseConfig) {
+        let mut db = Database::new(config);
 
         let mut root_group = Group::new("Root");
         root_group.children.push(Node::Entry(Entry::new()));
@@ -84,7 +81,7 @@ mod kdbx4_tests {
             password += &std::char::from_u32(random_char as u32).unwrap().to_string();
         }
 
-        let key_elements = Key::with_password(&password).get_key_elements().unwrap();
+        let key_elements = DatabaseKey::with_password(&password).get_key_elements().unwrap();
 
         let mut encrypted_db = Vec::new();
         dump_kdbx4(&db, &key_elements, &mut encrypted_db).unwrap();
@@ -95,153 +92,50 @@ mod kdbx4_tests {
     }
 
     #[test]
-    pub fn aes256_chacha20_aes() {
-        test_with_settings(
+    pub fn test_config_matrix() {
+        let outer_cipher_configs = [
             OuterCipherConfig::AES256,
-            CompressionConfig::GZip,
-            InnerCipherConfig::ChaCha20,
-            KdfConfig::Aes { rounds: 100 },
-        );
-    }
+            OuterCipherConfig::Twofish,
+            OuterCipherConfig::ChaCha20,
+        ];
 
-    #[test]
-    pub fn aes256_chacha20_argon2() {
-        test_with_settings(
-            OuterCipherConfig::AES256,
-            CompressionConfig::GZip,
-            InnerCipherConfig::ChaCha20,
-            KdfConfig::Argon2 {
-                iterations: 1000,
-                memory: 65536,
-                parallelism: 8,
-                version: argon2::Version::Version13,
-            },
-        );
-    }
+        let compression_configs = [CompressionConfig::None, CompressionConfig::GZip];
 
-    #[test]
-    pub fn aes256_chacha20_argon2_no_compression() {
-        test_with_settings(
-            OuterCipherConfig::AES256,
-            CompressionConfig::GZip,
-            InnerCipherConfig::ChaCha20,
-            KdfConfig::Argon2 {
-                iterations: 1000,
-                memory: 65536,
-                parallelism: 8,
-                version: argon2::Version::Version13,
-            },
-        );
-    }
-
-    #[test]
-    pub fn aes256_salsa20_aes() {
-        test_with_settings(
-            OuterCipherConfig::AES256,
-            CompressionConfig::GZip,
+        let inner_cipher_configs = [
+            InnerCipherConfig::Plain,
             InnerCipherConfig::Salsa20,
-            KdfConfig::Aes { rounds: 100 },
-        );
-    }
+            InnerCipherConfig::ChaCha20,
+        ];
 
-    #[test]
-    pub fn aes256_salsa20_argon2() {
-        test_with_settings(
-            OuterCipherConfig::AES256,
-            CompressionConfig::GZip,
-            InnerCipherConfig::Salsa20,
+        let kdf_configs = [
+            KdfConfig::Aes { rounds: 10 },
             KdfConfig::Argon2 {
-                iterations: 100,
+                iterations: 10,
                 memory: 65536,
-                parallelism: 1,
+                parallelism: 2,
                 version: argon2::Version::Version13,
             },
-        );
-    }
+        ];
 
-    #[test]
-    pub fn chacha20_chacha20_aes() {
-        test_with_settings(
-            OuterCipherConfig::ChaCha20,
-            CompressionConfig::GZip,
-            InnerCipherConfig::ChaCha20,
-            KdfConfig::Aes { rounds: 100 },
-        );
-    }
+        for outer_cipher_config in &outer_cipher_configs {
+            for compression_config in &compression_configs {
+                for inner_cipher_config in &inner_cipher_configs {
+                    for kdf_config in &kdf_configs {
+                        let config = DatabaseConfig {
+                            version: DatabaseVersion::KDB4(KDBX4_CURRENT_MINOR_VERSION),
+                            outer_cipher_config: outer_cipher_config.clone(),
+                            compression_config: compression_config.clone(),
+                            inner_cipher_config: inner_cipher_config.clone(),
+                            kdf_config: kdf_config.clone(),
+                        };
 
-    #[test]
-    pub fn chacha20_chacha20_aes_no_compression() {
-        test_with_settings(
-            OuterCipherConfig::ChaCha20,
-            CompressionConfig::None,
-            InnerCipherConfig::ChaCha20,
-            KdfConfig::Aes { rounds: 100 },
-        );
-    }
+                        println!("Testing with config: {config:?}");
 
-    #[test]
-    pub fn chacha20_chacha20_argon2() {
-        test_with_settings(
-            OuterCipherConfig::ChaCha20,
-            CompressionConfig::GZip,
-            InnerCipherConfig::ChaCha20,
-            KdfConfig::Argon2 {
-                iterations: 1000,
-                memory: 65536,
-                parallelism: 8,
-                version: argon2::Version::Version13,
-            },
-        );
-    }
-
-    #[test]
-    pub fn chacha20_chacha20_argon2_no_compression() {
-        test_with_settings(
-            OuterCipherConfig::ChaCha20,
-            CompressionConfig::None,
-            InnerCipherConfig::ChaCha20,
-            KdfConfig::Argon2 {
-                iterations: 1000,
-                memory: 65536,
-                parallelism: 8,
-                version: argon2::Version::Version13,
-            },
-        );
-    }
-
-    #[test]
-    pub fn twofish_chacha20_aes() {
-        test_with_settings(
-            OuterCipherConfig::Twofish,
-            CompressionConfig::GZip,
-            InnerCipherConfig::ChaCha20,
-            KdfConfig::Aes { rounds: 100 },
-        );
-    }
-
-    #[test]
-    pub fn twofish_chacha20_aes_no_compression() {
-        test_with_settings(
-            OuterCipherConfig::Twofish,
-            CompressionConfig::None,
-            InnerCipherConfig::ChaCha20,
-            KdfConfig::Aes { rounds: 100 },
-        );
-    }
-
-    #[test]
-    pub fn twofish_chacha20_argon2() {
-        test_with_settings(
-            OuterCipherConfig::Twofish,
-            CompressionConfig::GZip,
-            InnerCipherConfig::ChaCha20,
-            KdfConfig::Argon2 {
-                iterations: 1000,
-                memory: 65536,
-                parallelism: 8,
-                version: argon2::Version::Version13,
-            },
-        );
+                        test_with_config(config);
+                    }
+                }
+            }
+        }
     }
 
     #[test]
@@ -249,7 +143,7 @@ mod kdbx4_tests {
         let mut root_group = Group::new("Root");
         root_group.children.push(Node::Entry(Entry::new()));
 
-        let mut db = Database::new(DatabaseSettings::default());
+        let mut db = Database::new(DatabaseConfig::default());
 
         db.header_attachments = vec![
             HeaderAttachment {
@@ -270,7 +164,7 @@ mod kdbx4_tests {
 
         db.root.children.push(Node::Entry(entry));
 
-        let key_elements = Key::with_password("test").get_key_elements().unwrap();
+        let key_elements = DatabaseKey::with_password("test").get_key_elements().unwrap();
 
         let mut encrypted_db = Vec::new();
         dump_kdbx4(&db, &key_elements, &mut encrypted_db).unwrap();

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 
-use crate::DatabaseIntegrityError;
+use crate::error::DatabaseIntegrityError;
 
 const KDBX_IDENTIFIER: [u8; 4] = [0x03, 0xd9, 0xa2, 0x9a];
 

--- a/src/hmac_block_stream.rs
+++ b/src/hmac_block_stream.rs
@@ -7,6 +7,7 @@ use crate::crypt::CryptographyError;
 
 pub const HMAC_KEY_END: [u8; 1] = hex!("01");
 
+/// Errors reading from the HMAC block stream
 #[derive(Debug, Error)]
 pub enum BlockStreamError {
     #[error(transparent)]

--- a/src/hmac_block_stream.rs
+++ b/src/hmac_block_stream.rs
@@ -1,21 +1,10 @@
 use byteorder::{ByteOrder, LittleEndian};
 use cipher::generic_array::{typenum::U64, GenericArray};
 use hex_literal::hex;
-use thiserror::Error;
 
-use crate::crypt::CryptographyError;
+use crate::error::{BlockStreamError, CryptographyError};
 
 pub const HMAC_KEY_END: [u8; 1] = hex!("01");
-
-/// Errors reading from the HMAC block stream
-#[derive(Debug, Error)]
-pub enum BlockStreamError {
-    #[error(transparent)]
-    Cryptography(#[from] CryptographyError),
-
-    #[error("Block hash mismatch for block {}", block_index)]
-    BlockHashMismatch { block_index: u64 },
-}
 
 const DEFAULT_BLOCK_SIZE: u32 = 1024 * 1024;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,15 @@
 mod compression;
 mod config;
 pub(crate) mod crypt;
-mod db;
+pub mod db;
+pub mod error;
 pub(crate) mod format;
 pub(crate) mod hmac_block_stream;
 mod io;
-mod keyfile;
+mod key;
 pub(crate) mod variant_dictionary;
 pub(crate) mod xml_db;
 
-pub use self::db::*;
+pub use self::db::Database;
+pub use self::key::Key;
 // see https://gist.github.com/msmuenchen/9318327 for file format details

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![recursion_limit = "1024"]
 
 mod compression;
-mod config;
+pub mod config;
 pub(crate) mod crypt;
 pub mod db;
 pub mod error;
@@ -14,5 +14,4 @@ pub(crate) mod variant_dictionary;
 pub(crate) mod xml_db;
 
 pub use self::db::Database;
-pub use self::key::Key;
-// see https://gist.github.com/msmuenchen/9318327 for file format details
+pub use self::key::DatabaseKey;

--- a/src/variant_dictionary.rs
+++ b/src/variant_dictionary.rs
@@ -20,6 +20,7 @@ pub(crate) struct VariantDictionary {
     pub data: HashMap<String, VariantDictionaryValue>,
 }
 
+/// Errors while parsing a VariantDictionary
 #[derive(Debug, Error)]
 pub enum VariantDictionaryError {
     #[error("Invalid variant dictionary version: {}", version)]
@@ -39,7 +40,7 @@ pub enum VariantDictionaryError {
 }
 
 impl VariantDictionary {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             data: HashMap::new(),
         }

--- a/src/variant_dictionary.rs
+++ b/src/variant_dictionary.rs
@@ -1,8 +1,7 @@
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use std::{collections::HashMap, io::Write};
-use thiserror::Error;
 
-use crate::io::WriteLengthTaggedExt;
+use crate::{error::VariantDictionaryError, io::WriteLengthTaggedExt};
 
 pub const VARIANT_DICTIONARY_VERSION: u16 = 0x100;
 pub const VARIANT_DICTIONARY_END: u8 = 0x0;
@@ -18,25 +17,6 @@ pub const BYTES_TYPE_ID: u8 = 0x42;
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct VariantDictionary {
     pub data: HashMap<String, VariantDictionaryValue>,
-}
-
-/// Errors while parsing a VariantDictionary
-#[derive(Debug, Error)]
-pub enum VariantDictionaryError {
-    #[error("Invalid variant dictionary version: {}", version)]
-    InvalidVersion { version: u16 },
-
-    #[error("Invalid value type: {}", value_type)]
-    InvalidValueType { value_type: u8 },
-
-    #[error("Missing key: {}", key)]
-    MissingKey { key: String },
-
-    #[error("Mistyped value: {}", key)]
-    Mistyped { key: String },
-
-    #[error("VariantDictionary did not end with null byte, when it should")]
-    NotTerminated,
 }
 
 impl VariantDictionary {

--- a/src/xml_db/dump/entry.rs
+++ b/src/xml_db/dump/entry.rs
@@ -3,9 +3,8 @@ use xml::writer::{EventWriter, XmlEvent as WriterEvent};
 
 use crate::{
     crypt::ciphers::Cipher,
-    entry::History,
+    db::{AutoType, AutoTypeAssociation, Entry, History, Value},
     xml_db::dump::{DumpXml, SimpleTag},
-    AutoType, AutoTypeAssociation, Entry, Value,
 };
 
 impl DumpXml for Entry {

--- a/src/xml_db/dump/group.rs
+++ b/src/xml_db/dump/group.rs
@@ -2,8 +2,8 @@ use xml::writer::{EventWriter, XmlEvent as WriterEvent};
 
 use crate::{
     crypt::ciphers::Cipher,
+    db::{Group, Node},
     xml_db::dump::{DumpXml, SimpleTag},
-    Group, Node,
 };
 
 impl DumpXml for Group {

--- a/src/xml_db/dump/meta.rs
+++ b/src/xml_db/dump/meta.rs
@@ -2,11 +2,10 @@ use base64::{engine::general_purpose as base64_engine, Engine as _};
 use xml::writer::{EventWriter, XmlEvent as WriterEvent};
 
 use crate::{
-    compression::{Decompress, GZipCompression},
+    compression::{Compression, GZipCompression},
     crypt::ciphers::Cipher,
-    meta::{BinaryAttachments, CustomIcons, Icon, MemoryProtection},
+    db::meta::{BinaryAttachment, BinaryAttachments, CustomIcons, Icon, MemoryProtection, Meta},
     xml_db::dump::{DumpXml, SimpleTag},
-    BinaryAttachment, Meta,
 };
 
 impl DumpXml for Meta {

--- a/src/xml_db/dump/mod.rs
+++ b/src/xml_db/dump/mod.rs
@@ -12,9 +12,8 @@ use xml::{
 
 use crate::{
     crypt::ciphers::Cipher,
-    db::{Database, Times},
+    db::{CustomData, CustomDataItem, Database, Times},
     xml_db::get_epoch_baseline,
-    CustomData, CustomDataItem,
 };
 
 /// Format a timestamp suitable for an XML database

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -13,11 +13,14 @@ mod tests {
     use secstr::SecStr;
 
     use crate::{
-        entry::History,
+        db::{
+            entry::History,
+            meta::{BinaryAttachments, CustomIcons, Icon, MemoryProtection},
+            AutoType, AutoTypeAssociation, BinaryAttachment, CustomData, CustomDataItem, Database,
+            DatabaseSettings, Entry, Group, Meta, Node, Value,
+        },
         format::kdbx4,
-        meta::{BinaryAttachments, CustomIcons, Icon, MemoryProtection},
-        AutoTypeAssociation, BinaryAttachment, CustomData, CustomDataItem, Database, Entry, Group,
-        Meta, Node, Value,
+        key::Key,
     };
 
     fn make_key() -> Vec<Vec<u8>> {
@@ -29,7 +32,7 @@ mod tests {
             password += &std::char::from_u32(random_char as u32).unwrap().to_string();
         }
 
-        let key_elements = Database::get_key_elements(Some(&password), None).unwrap();
+        let key_elements = Key::with_password(&password).get_key_elements().unwrap();
         key_elements
     }
 
@@ -38,17 +41,16 @@ mod tests {
         let mut root_group = Group::new("Root");
         let mut entry = Entry::new();
 
-        entry.fields.insert(
-            "Title".to_string(),
-            crate::Value::Unprotected("ASDF".to_string()),
-        );
+        entry
+            .fields
+            .insert("Title".to_string(), Value::Unprotected("ASDF".to_string()));
         entry.fields.insert(
             "UserName".to_string(),
-            crate::Value::Unprotected("ghj".to_string()),
+            Value::Unprotected("ghj".to_string()),
         );
         entry.fields.insert(
             "Password".to_string(),
-            crate::Value::Protected(std::str::from_utf8(b"klmno").unwrap().into()),
+            Value::Protected(std::str::from_utf8(b"klmno").unwrap().into()),
         );
         entry.tags.push("test".to_string());
         entry.tags.push("keepass-rs".to_string());
@@ -58,7 +60,7 @@ mod tests {
             .times
             .times
             .insert("Created".to_string(), NaiveDateTime::default());
-        entry.autotype = Some(crate::AutoType {
+        entry.autotype = Some(AutoType {
             enabled: true,
             sequence: Some("Autotype-sequence".to_string()),
             associations: vec![
@@ -95,7 +97,7 @@ mod tests {
 
         root_group.children.push(Node::Entry(entry.clone()));
 
-        let mut db = Database::new(crate::DatabaseSettings::default());
+        let mut db = Database::new(DatabaseSettings::default());
         db.root = root_group;
 
         let key_elements = make_key();
@@ -119,10 +121,9 @@ mod tests {
         let mut root_group = Group::new("Root");
         let mut entry = Entry::new();
         let new_entry_uuid = entry.uuid.clone();
-        entry.fields.insert(
-            "Title".to_string(),
-            crate::Value::Unprotected("ASDF".to_string()),
-        );
+        entry
+            .fields
+            .insert("Title".to_string(), Value::Unprotected("ASDF".to_string()));
 
         root_group.children.push(Node::Entry(entry));
 
@@ -146,7 +147,7 @@ mod tests {
 
         root_group.children.push(Node::Group(subgroup));
 
-        let mut db = Database::new(crate::DatabaseSettings::default());
+        let mut db = Database::new(DatabaseSettings::default());
         db.root = root_group.clone();
 
         let key_elements = make_key();
@@ -170,7 +171,7 @@ mod tests {
 
     #[test]
     pub fn test_meta() {
-        let mut db = Database::new(crate::DatabaseSettings::default());
+        let mut db = Database::new(DatabaseSettings::default());
 
         let meta = Meta {
             generator: Some("test-generator".to_string()),

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -13,14 +13,15 @@ mod tests {
     use secstr::SecStr;
 
     use crate::{
+        config::DatabaseConfig,
         db::{
             entry::History,
             meta::{BinaryAttachments, CustomIcons, Icon, MemoryProtection},
             AutoType, AutoTypeAssociation, BinaryAttachment, CustomData, CustomDataItem, Database,
-            DatabaseSettings, Entry, Group, Meta, Node, Value,
+            Entry, Group, Meta, Node, Value,
         },
         format::kdbx4,
-        key::Key,
+        key::DatabaseKey,
     };
 
     fn make_key() -> Vec<Vec<u8>> {
@@ -32,7 +33,9 @@ mod tests {
             password += &std::char::from_u32(random_char as u32).unwrap().to_string();
         }
 
-        let key_elements = Key::with_password(&password).get_key_elements().unwrap();
+        let key_elements = DatabaseKey::with_password(&password)
+            .get_key_elements()
+            .unwrap();
         key_elements
     }
 
@@ -97,7 +100,7 @@ mod tests {
 
         root_group.children.push(Node::Entry(entry.clone()));
 
-        let mut db = Database::new(DatabaseSettings::default());
+        let mut db = Database::new(DatabaseConfig::default());
         db.root = root_group;
 
         let key_elements = make_key();
@@ -147,7 +150,7 @@ mod tests {
 
         root_group.children.push(Node::Group(subgroup));
 
-        let mut db = Database::new(DatabaseSettings::default());
+        let mut db = Database::new(DatabaseConfig::default());
         db.root = root_group.clone();
 
         let key_elements = make_key();
@@ -171,7 +174,7 @@ mod tests {
 
     #[test]
     pub fn test_meta() {
-        let mut db = Database::new(DatabaseSettings::default());
+        let mut db = Database::new(DatabaseConfig::default());
 
         let meta = Meta {
             generator: Some("test-generator".to_string()),

--- a/src/xml_db/parse/entry.rs
+++ b/src/xml_db/parse/entry.rs
@@ -5,9 +5,8 @@ use secstr::SecStr;
 
 use crate::{
     crypt::ciphers::Cipher,
-    entry::History,
+    db::{AutoType, AutoTypeAssociation, Entry, History, Times, Value},
     xml_db::parse::{CustomData, FromXml, SimpleTag, SimpleXmlEvent, XmlParseError},
-    AutoType, AutoTypeAssociation, Entry, Times, Value,
 };
 
 use super::IgnoreSubfield;

--- a/src/xml_db/parse/group.rs
+++ b/src/xml_db/parse/group.rs
@@ -1,6 +1,6 @@
 use crate::{
+    db::{Entry, Group, Node, Times},
     xml_db::parse::{FromXml, SimpleTag, SimpleXmlEvent, XmlParseError},
-    Entry, Group, Node, Times,
 };
 
 use super::IgnoreSubfield;
@@ -99,8 +99,8 @@ impl FromXml for Group {
 mod parse_group_test {
 
     use crate::{
+        db::Group,
         xml_db::parse::{parse_test::parse_test_xml, XmlParseError},
-        Group,
     };
 
     #[test]

--- a/src/xml_db/parse/meta.rs
+++ b/src/xml_db/parse/meta.rs
@@ -2,10 +2,9 @@ use base64::{engine::general_purpose as base64_engine, Engine as _};
 use chrono::NaiveDateTime;
 
 use crate::{
-    compression::{Decompress, GZipCompression},
-    meta::{BinaryAttachment, BinaryAttachments, CustomIcons, Icon, MemoryProtection},
+    compression::{Compression, GZipCompression},
+    db::meta::{BinaryAttachment, BinaryAttachments, CustomIcons, Icon, MemoryProtection, Meta},
     xml_db::parse::{CustomData, FromXml, SimpleTag, SimpleXmlEvent, XmlParseError},
-    Meta,
 };
 
 use super::IgnoreSubfield;
@@ -307,7 +306,7 @@ impl FromXml for BinaryAttachment {
         out.identifier = identifier;
         out.compressed = compressed;
         out.content = if compressed {
-            Decompress::decompress(&GZipCompression, &buf).map_err(XmlParseError::Compression)?
+            Compression::decompress(&GZipCompression, &buf).map_err(XmlParseError::Compression)?
         } else {
             buf
         };
@@ -417,9 +416,10 @@ impl FromXml for Icon {
 mod parse_meta_test {
 
     use crate::{
-        meta::{BinaryAttachments, CustomIcons, Icon, MemoryProtection},
+        db::meta::{
+            BinaryAttachment, BinaryAttachments, CustomIcons, Icon, MemoryProtection, Meta,
+        },
         xml_db::parse::{parse_test::parse_test_xml, XmlParseError},
-        BinaryAttachment, Meta,
     };
 
     #[test]

--- a/tests/entry_tests.rs
+++ b/tests/entry_tests.rs
@@ -2,14 +2,17 @@ mod entry_tests {
     use keepass::{
         db::{Database, NodeRef},
         error::{DatabaseKeyError, DatabaseOpenError},
-        Key,
+        DatabaseKey,
     };
     use std::{fs::File, path::Path};
 
     #[test]
     fn kdbx3_entry() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_with_password.kdbx");
-        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::with_password("demopass"),
+        )?;
 
         // get an entry on the root node
         if let Some(NodeRef::Entry(e)) = db.root.get(&["Sample Entry"]) {
@@ -64,7 +67,10 @@ mod entry_tests {
     fn kdbx4_entry() -> Result<(), DatabaseOpenError> {
         // KDBX4 database format Base64 encodes ExpiryTime (and all other XML timestamps)
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
-        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::with_password("demopass"),
+        )?;
 
         // get an entry on the root node
         if let Some(NodeRef::Entry(e)) = db.root.get(&["ASDF"]) {
@@ -91,7 +97,7 @@ mod entry_tests {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
         let db = Database::open(
             &mut File::open(path)?,
-            Key::with_password("this password is not correct"),
+            DatabaseKey::with_password("this password is not correct"),
         );
 
         assert!(db.is_err());

--- a/tests/entry_tests.rs
+++ b/tests/entry_tests.rs
@@ -1,11 +1,15 @@
 mod entry_tests {
-    use keepass::*;
+    use keepass::{
+        db::{Database, NodeRef},
+        error::{DatabaseKeyError, DatabaseOpenError},
+        Key,
+    };
     use std::{fs::File, path::Path};
 
     #[test]
     fn kdbx3_entry() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_with_password.kdbx");
-        let db = Database::open(&mut File::open(path)?, Some("demopass"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
 
         // get an entry on the root node
         if let Some(NodeRef::Entry(e)) = db.root.get(&["Sample Entry"]) {
@@ -60,7 +64,7 @@ mod entry_tests {
     fn kdbx4_entry() -> Result<(), DatabaseOpenError> {
         // KDBX4 database format Base64 encodes ExpiryTime (and all other XML timestamps)
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
-        let db = Database::open(&mut File::open(path)?, Some("demopass"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
 
         // get an entry on the root node
         if let Some(NodeRef::Entry(e)) = db.root.get(&["ASDF"]) {
@@ -87,8 +91,7 @@ mod entry_tests {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
         let db = Database::open(
             &mut File::open(path)?,
-            Some("this password is not correct"),
-            None,
+            Key::with_password("this password is not correct"),
         );
 
         assert!(db.is_err());

--- a/tests/file_read_tests.rs
+++ b/tests/file_read_tests.rs
@@ -2,14 +2,17 @@ mod file_read_tests {
     use keepass::{
         db::{Database, NodeRef},
         error::{DatabaseIntegrityError, DatabaseOpenError},
-        Key,
+        DatabaseKey,
     };
     use std::{fs::File, path::Path};
 
     #[test]
     fn open_kdbx3_with_password() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_with_password.kdbx");
-        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::with_password("demopass"),
+        )?;
 
         println!("{:?} DB Opened", db);
         assert_eq!(db.root.name, "sample");
@@ -47,7 +50,7 @@ mod file_read_tests {
         let kf_path = Path::new("tests/resources/test_key.key");
         let db = Database::open(
             &mut File::open(path)?,
-            Key::with_keyfile(&mut File::open(kf_path)?),
+            DatabaseKey::with_keyfile(&mut File::open(kf_path)?),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -86,7 +89,7 @@ mod file_read_tests {
         let kf_path = Path::new("tests/resources/test_key_xml.key");
         let db = Database::open(
             &mut File::open(path)?,
-            Key::with_keyfile(&mut File::open(kf_path)?),
+            DatabaseKey::with_keyfile(&mut File::open(kf_path)?),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -123,7 +126,10 @@ mod file_read_tests {
     fn open_kdbx4_with_password_kdf_argon2_cipher_aes() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_argon2.kdbx");
 
-        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::with_password("demopass"),
+        )?;
 
         println!("{:?} DB Opened", db);
 
@@ -136,7 +142,10 @@ mod file_read_tests {
     #[test]
     fn open_kdbx4_with_password_kdf_aes_cipher_aes() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
-        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::with_password("demopass"),
+        )?;
 
         println!("{:?} DB Opened", db);
 
@@ -150,7 +159,10 @@ mod file_read_tests {
     fn open_kdbx4_with_password_kdf_argon2_cipher_twofish() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_argon2_twofish.kdbx");
 
-        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::with_password("demopass"),
+        )?;
 
         println!("{:?} DB Opened", db);
 
@@ -164,7 +176,10 @@ mod file_read_tests {
     fn open_kdbx4_with_password_kdf_argon2_cipher_chacha20() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_argon2_chacha20.kdbx");
 
-        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::with_password("demopass"),
+        )?;
 
         println!("{:?} DB Opened", db);
 
@@ -181,7 +196,7 @@ mod file_read_tests {
 
         let db = Database::open(
             &mut File::open(path)?,
-            Key::with_keyfile(&mut File::open(kf_path)?),
+            DatabaseKey::with_keyfile(&mut File::open(kf_path)?),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -196,20 +211,28 @@ mod file_read_tests {
     #[should_panic(expected = r#"InvalidKDBXIdentifier"#)]
     fn open_broken_random_data() {
         let path = Path::new("tests/resources/broken_random_data.kdbx");
-        Database::open(&mut File::open(path).unwrap(), Key::with_password("")).unwrap();
+        Database::open(
+            &mut File::open(path).unwrap(),
+            DatabaseKey::with_password(""),
+        )
+        .unwrap();
     }
 
     #[test]
     #[should_panic(expected = r#"InvalidKDBXVersion"#)]
     fn open_broken_kdbx_version() {
         let path = Path::new("tests/resources/broken_kdbx_version.kdbx");
-        Database::open(&mut File::open(path).unwrap(), Key::with_password("")).unwrap();
+        Database::open(
+            &mut File::open(path).unwrap(),
+            DatabaseKey::with_password(""),
+        )
+        .unwrap();
     }
 
     #[test]
     fn open_kdb_with_password() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdb_with_password.kdb");
-        let db = Database::open(&mut File::open(path)?, Key::with_password("foobar"))?;
+        let db = Database::open(&mut File::open(path)?, DatabaseKey::with_password("foobar"))?;
 
         println!("{:?} DB Opened", db);
         assert_eq!(db.root.name, "Root");
@@ -244,7 +267,10 @@ mod file_read_tests {
     #[test]
     fn open_kdb_with_larger_than_1mb_file_does_not_crash() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdb3_with_file_larger_1mb.kdbx");
-        let db = Database::open(&mut File::open(path)?, Key::with_password("samplepassword"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::with_password("samplepassword"),
+        )?;
 
         println!("{:?} DB Opened", db);
         assert_eq!(db.root.children.len(), 1);
@@ -278,7 +304,10 @@ mod file_read_tests {
     fn open_kdbx4_with_password_deleted_entry() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_deleted_entry.kdbx");
 
-        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::with_password("demopass"),
+        )?;
 
         println!("{:?} DB Opened", db);
 

--- a/tests/file_read_tests.rs
+++ b/tests/file_read_tests.rs
@@ -1,11 +1,15 @@
 mod file_read_tests {
-    use keepass::*;
+    use keepass::{
+        db::{Database, NodeRef},
+        error::{DatabaseIntegrityError, DatabaseOpenError},
+        Key,
+    };
     use std::{fs::File, path::Path};
 
     #[test]
     fn open_kdbx3_with_password() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_with_password.kdbx");
-        let db = Database::open(&mut File::open(path)?, Some("demopass"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
 
         println!("{:?} DB Opened", db);
         assert_eq!(db.root.name, "sample");
@@ -43,8 +47,7 @@ mod file_read_tests {
         let kf_path = Path::new("tests/resources/test_key.key");
         let db = Database::open(
             &mut File::open(path)?,
-            None,
-            Some(&mut File::open(kf_path)?),
+            Key::with_keyfile(&mut File::open(kf_path)?),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -83,8 +86,7 @@ mod file_read_tests {
         let kf_path = Path::new("tests/resources/test_key_xml.key");
         let db = Database::open(
             &mut File::open(path)?,
-            None,
-            Some(&mut File::open(kf_path)?),
+            Key::with_keyfile(&mut File::open(kf_path)?),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -121,7 +123,7 @@ mod file_read_tests {
     fn open_kdbx4_with_password_kdf_argon2_cipher_aes() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_argon2.kdbx");
 
-        let db = Database::open(&mut File::open(path)?, Some("demopass"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
 
         println!("{:?} DB Opened", db);
 
@@ -134,7 +136,7 @@ mod file_read_tests {
     #[test]
     fn open_kdbx4_with_password_kdf_aes_cipher_aes() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
-        let db = Database::open(&mut File::open(path)?, Some("demopass"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
 
         println!("{:?} DB Opened", db);
 
@@ -148,7 +150,7 @@ mod file_read_tests {
     fn open_kdbx4_with_password_kdf_argon2_cipher_twofish() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_argon2_twofish.kdbx");
 
-        let db = Database::open(&mut File::open(path)?, Some("demopass"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
 
         println!("{:?} DB Opened", db);
 
@@ -162,7 +164,7 @@ mod file_read_tests {
     fn open_kdbx4_with_password_kdf_argon2_cipher_chacha20() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_argon2_chacha20.kdbx");
 
-        let db = Database::open(&mut File::open(path)?, Some("demopass"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
 
         println!("{:?} DB Opened", db);
 
@@ -179,8 +181,7 @@ mod file_read_tests {
 
         let db = Database::open(
             &mut File::open(path)?,
-            None,
-            Some(&mut File::open(kf_path)?),
+            Key::with_keyfile(&mut File::open(kf_path)?),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -195,20 +196,20 @@ mod file_read_tests {
     #[should_panic(expected = r#"InvalidKDBXIdentifier"#)]
     fn open_broken_random_data() {
         let path = Path::new("tests/resources/broken_random_data.kdbx");
-        Database::open(&mut File::open(path).unwrap(), Some(""), None).unwrap();
+        Database::open(&mut File::open(path).unwrap(), Key::with_password("")).unwrap();
     }
 
     #[test]
     #[should_panic(expected = r#"InvalidKDBXVersion"#)]
     fn open_broken_kdbx_version() {
         let path = Path::new("tests/resources/broken_kdbx_version.kdbx");
-        Database::open(&mut File::open(path).unwrap(), Some(""), None).unwrap();
+        Database::open(&mut File::open(path).unwrap(), Key::with_password("")).unwrap();
     }
 
     #[test]
     fn open_kdb_with_password() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdb_with_password.kdb");
-        let db = Database::open(&mut File::open(path)?, Some("foobar"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("foobar"))?;
 
         println!("{:?} DB Opened", db);
         assert_eq!(db.root.name, "Root");
@@ -243,7 +244,7 @@ mod file_read_tests {
     #[test]
     fn open_kdb_with_larger_than_1mb_file_does_not_crash() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdb3_with_file_larger_1mb.kdbx");
-        let db = Database::open(&mut File::open(path)?, Some("samplepassword"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("samplepassword"))?;
 
         println!("{:?} DB Opened", db);
         assert_eq!(db.root.children.len(), 1);
@@ -277,7 +278,7 @@ mod file_read_tests {
     fn open_kdbx4_with_password_deleted_entry() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_deleted_entry.kdbx");
 
-        let db = Database::open(&mut File::open(path)?, Some("demopass"), None)?;
+        let db = Database::open(&mut File::open(path)?, Key::with_password("demopass"))?;
 
         println!("{:?} DB Opened", db);
 


### PR DESCRIPTION
This commit minimizes the public interface of the crate, and restructures it to make the docs more legible.

BREAKING CHANGE: Many visibility changes.

BREAKING CHANGE: Renamed and moved several types around.

BREAKING CHANGE: New Key type used to specify password and keyfile.