### PR TITLE
ci: cancel in progress workflows on prs

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,10 +1,15 @@
+---
+name: CI
+
 on:
   push:
     branches:
       - master
   pull_request:
 
-name: CI
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:


### PR DESCRIPTION
This commit will cancel the CI workflow when additional changes are pushed to the PR.