### PR TITLE
feat!: support DeletedObjects

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -47,6 +47,9 @@ pub struct Database {
     /// Root node of the KeePass database
     pub root: Group,
 
+    /// References to previously-deleted objects
+    pub deleted_objects: DeletedObjects,
+
     /// Metadata of the KeePass database
     pub meta: Meta,
 }
@@ -130,6 +133,7 @@ impl Database {
             config,
             header_attachments: Vec::new(),
             root: Group::new("Root"),
+            deleted_objects: Default::default(),
             meta: Default::default(),
         }
     }
@@ -180,6 +184,21 @@ pub struct CustomDataItem {
 pub struct HeaderAttachment {
     pub flags: u8,
     pub content: Vec<u8>,
+}
+
+/// Elements that have been previously deleted
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+pub struct DeletedObjects {
+    pub objects: Vec<DeletedObject>,
+}
+
+/// A refernece to a deleted element
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+pub struct DeletedObject {
+    pub uuid: String,
+    pub deletion_time: NaiveDateTime,
 }
 
 #[cfg(test)]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -193,7 +193,7 @@ pub struct DeletedObjects {
     pub objects: Vec<DeletedObject>,
 }
 
-/// A refernece to a deleted element
+/// A reference to a deleted element
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct DeletedObject {

--- a/src/format/kdb.rs
+++ b/src/format/kdb.rs
@@ -360,6 +360,7 @@ pub(crate) fn parse_kdb(
         config,
         header_attachments: Default::default(),
         root: root_group,
+        deleted_objects: Default::default(),
         meta: Default::default(),
     })
 }

--- a/src/format/kdbx3.rs
+++ b/src/format/kdbx3.rs
@@ -174,6 +174,7 @@ pub(crate) fn parse_kdbx3(
         config,
         header_attachments: Vec::new(),
         root: database_content.root.group,
+        deleted_objects: database_content.root.deleted_objects,
         meta: database_content.meta,
     };
 

--- a/src/format/kdbx4/parse.rs
+++ b/src/format/kdbx4/parse.rs
@@ -44,6 +44,7 @@ pub(crate) fn parse_kdbx4(
         config,
         header_attachments,
         root: database_content.root.group,
+        deleted_objects: database_content.root.deleted_objects,
         meta: database_content.meta,
     };
 

--- a/src/xml_db/dump/meta.rs
+++ b/src/xml_db/dump/meta.rs
@@ -114,8 +114,6 @@ impl DumpXml for Meta {
 
         self.custom_data.dump_xml(writer, inner_cipher)?;
 
-        // TODO DeletedObjects?
-
         writer.write(WriterEvent::end_element())?;
 
         Ok(())

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -18,7 +18,7 @@ mod tests {
             entry::History,
             meta::{BinaryAttachments, CustomIcons, Icon, MemoryProtection},
             AutoType, AutoTypeAssociation, BinaryAttachment, CustomData, CustomDataItem, Database,
-            Entry, Group, Meta, Node, Value,
+            DeletedObject, Entry, Group, Meta, Node, Value,
         },
         format::kdbx4,
         key::DatabaseKey,
@@ -261,5 +261,28 @@ mod tests {
         let decrypted_db = kdbx4::parse_kdbx4(&encrypted_db, &key_elements).unwrap();
 
         assert_eq!(decrypted_db.meta, meta);
+    }
+
+    #[test]
+    fn test_deleted_objects() {
+        let mut db = Database::new(DatabaseConfig::default());
+        db.deleted_objects.objects = vec![
+            DeletedObject {
+                uuid: "asdf-ghjk".to_string(),
+                deletion_time: "2000-12-31T12:34:56".parse().unwrap(),
+            },
+            DeletedObject {
+                uuid: "wdawdadw".to_string(),
+                deletion_time: "2000-12-31T12:35:00".parse().unwrap(),
+            },
+        ];
+
+        let key_elements = make_key();
+
+        let mut encrypted_db = Vec::new();
+        kdbx4::dump_kdbx4(&db, &key_elements, &mut encrypted_db).unwrap();
+        let decrypted_db = kdbx4::parse_kdbx4(&encrypted_db, &key_elements).unwrap();
+
+        assert_eq!(decrypted_db, db);
     }
 }

--- a/src/xml_db/parse/mod.rs
+++ b/src/xml_db/parse/mod.rs
@@ -10,7 +10,7 @@ use xml::{name::OwnedName, reader::XmlEvent, EventReader};
 
 use crate::{
     crypt::ciphers::Cipher,
-    db::{CustomData, CustomDataItem, Group, Meta, Times, Value},
+    db::{CustomData, CustomDataItem, DeletedObject, DeletedObjects, Group, Meta, Times, Value},
     error::XmlParseError,
     xml_db::get_epoch_baseline,
 };
@@ -374,11 +374,6 @@ impl FromXml for Root {
     }
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct DeletedObjects {
-    objects: Vec<DeletedObject>,
-}
-
 impl FromXml for DeletedObjects {
     type Parses = Self;
 
@@ -425,12 +420,6 @@ impl FromXml for DeletedObjects {
 
         Ok(out)
     }
-}
-
-#[derive(Debug, Default)]
-pub(crate) struct DeletedObject {
-    uuid: String,
-    deletion_time: NaiveDateTime,
 }
 
 impl FromXml for DeletedObject {


### PR DESCRIPTION
Closes #114

Parses and Dumps DeletedObject fields from the Root

BREAKING CHANGE: Adds new deleted_objects field to Database.