### PR TITLE
feat!: parse base64-encoded UUID values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ cipher = { version = "0.4", features = ["std"] }
 twofish = "0.7"
 cbc = "0.1"
 
-uuid = { version = "1.2", features = ["v4"] }
+uuid = { version = "1.2", features = ["v4", "serde"] }
 getrandom = { version = "0.2", features = ["std"] }
 
 # dependencies for command-line utilities

--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -12,7 +12,7 @@ use crate::db::otp::{TOTPError, TOTP};
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct Entry {
-    pub uuid: String,
+    pub uuid: Uuid,
     pub fields: HashMap<String, Value>,
     pub autotype: Option<AutoType>,
     pub tags: Vec<String>,
@@ -22,7 +22,7 @@ pub struct Entry {
     pub custom_data: CustomData,
 
     pub icon_id: Option<usize>,
-    pub custom_icon_uuid: Option<String>,
+    pub custom_icon_uuid: Option<Uuid>,
 
     pub foreground_color: Option<String>,
     pub background_color: Option<String>,
@@ -35,7 +35,7 @@ pub struct Entry {
 impl Entry {
     pub fn new() -> Entry {
         Entry {
-            uuid: Uuid::new_v4().to_string(),
+            uuid: Uuid::new_v4(),
             ..Default::default()
         }
     }
@@ -60,7 +60,7 @@ impl<'a> Entry {
         }
     }
 
-    pub fn get_uuid(&'a self) -> &'a str {
+    pub fn get_uuid(&'a self) -> &'a Uuid {
         &self.uuid
     }
 

--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -12,7 +12,7 @@ use crate::db::{
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct Group {
     /// The unique identifier of the group
-    pub uuid: String,
+    pub uuid: Uuid,
 
     /// The name of the group
     pub name: String,
@@ -24,7 +24,7 @@ pub struct Group {
     pub icon_id: Option<usize>,
 
     /// UUID for a custom group icon
-    pub custom_icon_uuid: Option<String>,
+    pub custom_icon_uuid: Option<Uuid>,
 
     /// The list of child nodes (Groups or Entries)
     pub children: Vec<Node>,
@@ -49,14 +49,14 @@ pub struct Group {
     /// UUID for the last top visible entry
     // TODO figure out what that is supposed to mean. According to the KeePass sourcecode, it has
     // something to do with restoring selected items when re-opening a database.
-    pub last_top_visible_entry: Option<String>,
+    pub last_top_visible_entry: Option<Uuid>,
 }
 
 impl Group {
     pub fn new(name: &str) -> Group {
         Group {
             name: name.to_string(),
-            uuid: Uuid::new_v4().to_string(),
+            uuid: Uuid::new_v4(),
             ..Default::default()
         }
     }

--- a/src/db/meta.rs
+++ b/src/db/meta.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDateTime;
+use uuid::Uuid;
 
 use crate::db::CustomData;
 
@@ -50,22 +51,22 @@ pub struct Meta {
     pub recyclebin_enabled: Option<bool>,
 
     /// A UUID for the recycle bin group
-    pub recyclebin_uuid: Option<String>,
+    pub recyclebin_uuid: Option<Uuid>,
 
     /// last time the recycle bin was changed
     pub recyclebin_changed: Option<NaiveDateTime>,
 
     /// UUID of the group containing entry templates
-    pub entry_templates_group: Option<String>,
+    pub entry_templates_group: Option<Uuid>,
 
     /// last time the group containing entry templates was changed
     pub entry_templates_group_changed: Option<NaiveDateTime>,
 
     /// UUID of the last selected group
-    pub last_selected_group: Option<String>,
+    pub last_selected_group: Option<Uuid>,
 
     /// UUID of the last top-visible group
-    pub last_top_visible_group: Option<String>,
+    pub last_top_visible_group: Option<Uuid>,
 
     /// Maximum number of items of history to keep
     pub history_max_items: Option<usize>,
@@ -127,7 +128,7 @@ pub struct CustomIcons {
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct Icon {
     /// UUID, to reference the icon
-    pub uuid: String,
+    pub uuid: Uuid,
 
     /// Image data
     pub data: Vec<u8>,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod otp;
 use std::collections::HashMap;
 
 use chrono::NaiveDateTime;
+use uuid::Uuid;
 
 pub use crate::db::{
     entry::{AutoType, AutoTypeAssociation, Entry, History, Value},
@@ -197,7 +198,7 @@ pub struct DeletedObjects {
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct DeletedObject {
-    pub uuid: String,
+    pub uuid: Uuid,
     pub deletion_time: NaiveDateTime,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -295,6 +295,9 @@ pub enum XmlParseError {
     BoolFormat(#[from] std::str::ParseBoolError),
 
     #[error(transparent)]
+    Uuid(#[from] uuid::Error),
+
+    #[error(transparent)]
     Cryptography(#[from] CryptographyError),
 
     #[error("Decompression error: {}", _0)]

--- a/src/xml_db/dump/mod.rs
+++ b/src/xml_db/dump/mod.rs
@@ -5,6 +5,7 @@ mod meta;
 use std::io::Write;
 
 use base64::{engine::general_purpose as base64_engine, Engine as _};
+use uuid::Uuid;
 use xml::{
     writer::{EventWriter, XmlEvent as WriterEvent},
     EmitterConfig,
@@ -110,6 +111,17 @@ impl DumpXml for &String {
         _inner_cipher: &mut dyn Cipher,
     ) -> Result<(), xml::writer::Error> {
         writer.write(WriterEvent::characters(self))
+    }
+}
+
+impl DumpXml for &Uuid {
+    fn dump_xml<E: std::io::Write>(
+        &self,
+        writer: &mut EventWriter<E>,
+        _inner_cipher: &mut dyn Cipher,
+    ) -> Result<(), xml::writer::Error> {
+        let b64 = base64_engine::STANDARD.encode(self.as_bytes());
+        writer.write(WriterEvent::Characters(&b64))
     }
 }
 

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -11,6 +11,7 @@ pub fn get_epoch_baseline() -> chrono::NaiveDateTime {
 mod tests {
     use chrono::NaiveDateTime;
     use secstr::SecStr;
+    use uuid::uuid;
 
     use crate::{
         config::DatabaseConfig,
@@ -85,7 +86,7 @@ mod tests {
         });
 
         entry.icon_id = Some(123);
-        entry.custom_icon_uuid = Some("custom-icon-uuid".to_string());
+        entry.custom_icon_uuid = Some(uuid!("22222222222222222222222222222222"));
 
         entry.foreground_color = Some("#C0FFEE".to_string());
         entry.background_color = Some("#1C1357".to_string());
@@ -133,7 +134,7 @@ mod tests {
         let mut subgroup = Group::new("Child group");
         subgroup.notes = Some("I am a subgroup".to_string());
         subgroup.icon_id = Some(42);
-        subgroup.custom_icon_uuid = Some("CUSTOM-ICON".to_string());
+        subgroup.custom_icon_uuid = Some(uuid!("11111111111111111111111111111111"));
         subgroup.times.expires = true;
         subgroup.times.usage_count = 100;
         subgroup
@@ -146,7 +147,7 @@ mod tests {
         subgroup.enable_autotype = Some("yes".to_string());
         subgroup.enable_searching = Some("sure".to_string());
 
-        subgroup.last_top_visible_entry = Some("an-entry".to_string());
+        subgroup.last_top_visible_entry = Some(uuid!("43210000000000000000000000000000"));
 
         root_group.children.push(Node::Group(subgroup));
 
@@ -167,7 +168,7 @@ mod tests {
         };
 
         assert_eq!(decrypted_entry.get_title(), Some("ASDF"));
-        assert_eq!(decrypted_entry.get_uuid(), new_entry_uuid);
+        assert_eq!(decrypted_entry.get_uuid(), &new_entry_uuid);
 
         assert_eq!(&decrypted_db.root, &root_group);
     }
@@ -198,17 +199,17 @@ mod tests {
             }),
             custom_icons: CustomIcons {
                 icons: vec![Icon {
-                    uuid: "a-fake-uuid".to_string(),
+                    uuid: uuid!("a1a2a3a4b1bffffffffffff4d5d6d7d8"),
                     data: b"fake-data".to_vec(),
                 }],
             },
             recyclebin_enabled: Some(true),
-            recyclebin_uuid: Some("another-fake-uuid".to_string()),
+            recyclebin_uuid: Some(uuid!("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8")),
             recyclebin_changed: Some("2000-12-31T12:35:00".parse().unwrap()),
-            entry_templates_group: Some("even-more-fake-uuid".to_string()),
+            entry_templates_group: Some(uuid!("123456789abcdef0d1d2d3d4d5d6d7d8")),
             entry_templates_group_changed: Some("2000-12-31T12:35:01".parse().unwrap()),
-            last_selected_group: Some("so-many-fake-uuids".to_string()),
-            last_top_visible_group: Some("hey-another-fake-uuid".to_string()),
+            last_selected_group: Some(uuid!("fffffffffffff1c2d1d2d3d4d5d6d7d8")),
+            last_top_visible_group: Some(uuid!("a1a2a3a4b1b2c1c2d1d2d3ffffffffff")),
             history_max_items: Some(456),
             history_max_size: Some(789),
             settings_changed: Some("2000-12-31T12:35:02".parse().unwrap()),
@@ -268,11 +269,11 @@ mod tests {
         let mut db = Database::new(DatabaseConfig::default());
         db.deleted_objects.objects = vec![
             DeletedObject {
-                uuid: "asdf-ghjk".to_string(),
+                uuid: uuid!("123e4567-e89b-12d3-a456-426655440000"),
                 deletion_time: "2000-12-31T12:34:56".parse().unwrap(),
             },
             DeletedObject {
-                uuid: "wdawdadw".to_string(),
+                uuid: uuid!("00112233-4455-6677-8899-aabbccddeeff"),
                 deletion_time: "2000-12-31T12:35:00".parse().unwrap(),
             },
         ];

--- a/src/xml_db/parse/entry.rs
+++ b/src/xml_db/parse/entry.rs
@@ -2,6 +2,7 @@ use std::iter::Peekable;
 
 use base64::{engine::general_purpose as base64_engine, Engine as _};
 use secstr::SecStr;
+use uuid::Uuid;
 
 use crate::{
     crypt::ciphers::Cipher,
@@ -32,7 +33,7 @@ impl FromXml for Entry {
             match event {
                 SimpleXmlEvent::Start(name, _) => match &name[..] {
                     "UUID" => {
-                        out.uuid = SimpleTag::<String>::from_xml(iterator, inner_cipher)?.value;
+                        out.uuid = SimpleTag::<Uuid>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Tags" => {
                         if let Some(tags) =
@@ -70,7 +71,7 @@ impl FromXml for Entry {
                     }
                     "CustomIconUUID" => {
                         out.custom_icon_uuid =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                            SimpleTag::<Option<Uuid>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "ForegroundColor" => {
                         out.foreground_color =

--- a/src/xml_db/parse/group.rs
+++ b/src/xml_db/parse/group.rs
@@ -1,3 +1,5 @@
+use uuid::Uuid;
+
 use crate::{
     db::{Entry, Group, Node, Times},
     xml_db::parse::{FromXml, SimpleTag, SimpleXmlEvent, XmlParseError},
@@ -26,7 +28,7 @@ impl FromXml for Group {
             match event {
                 SimpleXmlEvent::Start(name, _) => match &name[..] {
                     "UUID" => {
-                        out.uuid = SimpleTag::<String>::from_xml(iterator, inner_cipher)?.value;
+                        out.uuid = SimpleTag::<Uuid>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Name" => {
                         out.name = SimpleTag::<String>::from_xml(iterator, inner_cipher)?.value;
@@ -41,7 +43,7 @@ impl FromXml for Group {
                     }
                     "CustomIconUUID" => {
                         out.custom_icon_uuid =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                            SimpleTag::<Option<Uuid>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Times" => {
                         out.times = Times::from_xml(iterator, inner_cipher)?;
@@ -64,7 +66,7 @@ impl FromXml for Group {
                     }
                     "LastTopVisibleEntry" => {
                         out.last_top_visible_entry =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                            SimpleTag::<Option<Uuid>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Entry" => {
                         let entry = Entry::from_xml(iterator, inner_cipher)?;
@@ -103,6 +105,8 @@ mod parse_group_test {
         xml_db::parse::{parse_test::parse_test_xml, XmlParseError},
     };
 
+    use uuid::uuid;
+
     #[test]
     fn test_group() -> Result<(), XmlParseError> {
         let _value = parse_test_xml::<Group>("<Group></Group>")?;
@@ -110,9 +114,13 @@ mod parse_group_test {
         let value = parse_test_xml::<Group>("<Group><Notes>ASDF</Notes></Group>")?;
         assert_eq!(value.notes, Some("ASDF".to_string()));
 
-        let value =
-            parse_test_xml::<Group>("<Group><CustomIconUUID>ASDF</CustomIconUUID></Group>")?;
-        assert_eq!(value.custom_icon_uuid, Some("ASDF".to_string()));
+        let value = parse_test_xml::<Group>(
+            "<Group><CustomIconUUID>oaKjpLGywcLR0tPU1dbX2A==</CustomIconUUID></Group>",
+        )?;
+        assert_eq!(
+            value.custom_icon_uuid,
+            Some(uuid!("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8"))
+        );
 
         let value = parse_test_xml::<Group>("");
         assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));

--- a/src/xml_db/parse/meta.rs
+++ b/src/xml_db/parse/meta.rs
@@ -1,5 +1,6 @@
 use base64::{engine::general_purpose as base64_engine, Engine as _};
 use chrono::NaiveDateTime;
+use uuid::Uuid;
 
 use crate::{
     compression::{Compression, GZipCompression},
@@ -94,7 +95,7 @@ impl FromXml for Meta {
                     }
                     "RecycleBinUUID" => {
                         out.recyclebin_uuid =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                            SimpleTag::<Option<Uuid>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "RecycleBinChanged" => {
                         out.recyclebin_changed =
@@ -103,7 +104,7 @@ impl FromXml for Meta {
                     }
                     "EntryTemplatesGroup" => {
                         out.entry_templates_group =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                            SimpleTag::<Option<Uuid>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "EntryTemplatesGroupChanged" => {
                         out.entry_templates_group_changed =
@@ -112,11 +113,11 @@ impl FromXml for Meta {
                     }
                     "LastSelectedGroup" => {
                         out.last_selected_group =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                            SimpleTag::<Option<Uuid>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "LastTopVisibleGroup" => {
                         out.last_top_visible_group =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                            SimpleTag::<Option<Uuid>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "HistoryMaxItems" => {
                         out.history_max_items =
@@ -384,7 +385,7 @@ impl FromXml for Icon {
             match event {
                 SimpleXmlEvent::Start(name, _) => match &name[..] {
                     "UUID" => {
-                        out.uuid = SimpleTag::<String>::from_xml(iterator, inner_cipher)?.value;
+                        out.uuid = SimpleTag::<Uuid>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Data" => {
                         let data = SimpleTag::<String>::from_xml(iterator, inner_cipher)?.value;
@@ -421,6 +422,8 @@ mod parse_meta_test {
         },
         xml_db::parse::{parse_test::parse_test_xml, XmlParseError},
     };
+
+    use uuid::uuid;
 
     #[test]
     fn test_meta() -> Result<(), XmlParseError> {
@@ -528,12 +531,13 @@ mod parse_meta_test {
     #[test]
     fn test_custom_icon() -> Result<(), XmlParseError> {
         let value = parse_test_xml::<Icon>("<Icon></Icon>")?;
-        assert_eq!(value.uuid, "");
+        assert_eq!(value.uuid, Default::default());
         assert_eq!(value.data.len(), 0);
 
-        let value =
-            parse_test_xml::<Icon>("<Icon><UUID>asdf</UUID><Data>QmluYXJ5IERhdGE=</Data></Icon>")?;
-        assert_eq!(value.uuid, "asdf");
+        let value = parse_test_xml::<Icon>(
+            "<Icon><UUID>oaKjpLGywcLR0tPU1dbX2A==</UUID><Data>QmluYXJ5IERhdGE=</Data></Icon>",
+        )?;
+        assert_eq!(value.uuid, uuid!("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8"),);
         assert_eq!(value.data, r"Binary Data".as_bytes());
 
         let value = parse_test_xml::<Icon>("<TestTag>SomeData</TestTag>");

--- a/src/xml_db/parse/mod.rs
+++ b/src/xml_db/parse/mod.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, iter::Peekable};
 
 use base64::{engine::general_purpose as base64_engine, Engine as _};
 use chrono::NaiveDateTime;
+use uuid::Uuid;
 use xml::{name::OwnedName, reader::XmlEvent, EventReader};
 
 use crate::{
@@ -173,6 +174,14 @@ impl FromXmlCharacters for String {
 impl FromXmlCharacters for NaiveDateTime {
     fn from_xml_characters(s: &str) -> Result<Self, XmlParseError> {
         parse_xml_timestamp(s)
+    }
+}
+
+impl FromXmlCharacters for Uuid {
+    fn from_xml_characters(s: &str) -> Result<Self, XmlParseError> {
+        let v = base64_engine::STANDARD.decode(s)?;
+        let uuid = Uuid::from_slice(&v)?;
+        Ok(uuid)
     }
 }
 
@@ -443,7 +452,7 @@ impl FromXml for DeletedObject {
             match event {
                 SimpleXmlEvent::Start(name, _) => match &name[..] {
                     "UUID" => {
-                        out.uuid = SimpleTag::<String>::from_xml(iterator, inner_cipher)?.value;
+                        out.uuid = SimpleTag::<Uuid>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "DeletionTime" => {
                         out.deletion_time =

--- a/tests/entry_tests.rs
+++ b/tests/entry_tests.rs
@@ -5,6 +5,7 @@ mod entry_tests {
         DatabaseKey,
     };
     use std::{fs::File, path::Path};
+    use uuid::uuid;
 
     #[test]
     fn kdbx3_entry() -> Result<(), DatabaseOpenError> {
@@ -16,7 +17,7 @@ mod entry_tests {
 
         // get an entry on the root node
         if let Some(NodeRef::Entry(e)) = db.root.get(&["Sample Entry"]) {
-            assert_eq!(e.get_uuid(), "Dr7dsu1OUUS8NBowkmalEw==");
+            assert_eq!(e.get_uuid(), &uuid!("0ebeddb2-ed4e-5144-bc34-1a309266a513"));
             assert_eq!(e.get_title(), Some("Sample Entry"));
             assert_eq!(e.get_username(), Some("User Name"));
             assert_eq!(e.get_password(), Some("Password"));
@@ -45,7 +46,7 @@ mod entry_tests {
         }
 
         if let Some(NodeRef::Entry(e)) = db.root.get(&["General", "Subgroup", "test entry"]) {
-            assert_eq!(e.get_uuid(), "XkyK0ZzVOUyQORF43BQLSg==");
+            assert_eq!(e.get_uuid(), &uuid!("5e4c8ad1-9cd5-394c-9039-1178dc140b4a"));
             assert_eq!(e.get_title(), Some("test entry"));
             assert_eq!(e.get_username(), Some("jdoe"));
             assert_eq!(e.get_password(), Some("nWuu5AtqsxqNhnYgLwoB"));
@@ -74,7 +75,7 @@ mod entry_tests {
 
         // get an entry on the root node
         if let Some(NodeRef::Entry(e)) = db.root.get(&["ASDF"]) {
-            assert_eq!(e.get_uuid(), "TzgWvYMwSGWHn6EIoS8oXA==");
+            assert_eq!(e.get_uuid(), &uuid!("4f3816bd83304865879fa108a12f285c"));
             assert_eq!(e.get_title(), Some("ASDF"));
             assert_eq!(e.get_username(), Some("ghj"));
             assert_eq!(e.get_password(), Some("klmno"));

--- a/tests/file_read_tests.rs
+++ b/tests/file_read_tests.rs
@@ -4,6 +4,8 @@ mod file_read_tests {
         error::{DatabaseIntegrityError, DatabaseOpenError},
         DatabaseKey,
     };
+    use uuid::uuid;
+
     use std::{fs::File, path::Path};
 
     #[test]
@@ -314,7 +316,7 @@ mod file_read_tests {
         assert_eq!(db.root.name, "Root");
         assert_eq!(
             db.meta.recyclebin_uuid,
-            Some("VjFx/mWYQtyAA/mN3jLocg==".to_string())
+            Some(uuid!("563171fe-6598-42dc-8003-f98dde32e872"))
         );
 
         let recycle_group: Vec<NodeRef> = db


### PR DESCRIPTION
Closes #131

Instead of keeping the UUIDs of objects around as base64-encoded strings, actually parse them into Uuid objects. This also fixes some issues where UUID strings instead of base64-encoded UUIDs were serialized into the XML files.

BREAKING CHANGE: Changed type of UUID values from String to `uuid::Uuid`