### PR TITLE
feat!: parse colors

### DIFF
--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use secstr::SecStr;
 use uuid::Uuid;
 
-use crate::db::{CustomData, Times};
+use crate::db::{Color, CustomData, Times};
 
 #[cfg(feature = "totp")]
 use crate::db::otp::{TOTPError, TOTP};
@@ -24,8 +24,8 @@ pub struct Entry {
     pub icon_id: Option<usize>,
     pub custom_icon_uuid: Option<Uuid>,
 
-    pub foreground_color: Option<String>,
-    pub background_color: Option<String>,
+    pub foreground_color: Option<Color>,
+    pub background_color: Option<Color>,
 
     pub override_url: Option<String>,
     pub quality_check: Option<bool>,

--- a/src/db/meta.rs
+++ b/src/db/meta.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use uuid::Uuid;
 
-use crate::db::CustomData;
+use crate::db::{Color, CustomData};
 
 /// Database metadata
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
@@ -32,7 +32,7 @@ pub struct Meta {
     pub maintenance_history_days: Option<usize>,
 
     /// color code for the database
-    pub color: Option<String>,
+    pub color: Option<Color>,
 
     /// time the master key was last changed
     pub master_key_changed: Option<NaiveDateTime>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -298,6 +298,9 @@ pub enum XmlParseError {
     Uuid(#[from] uuid::Error),
 
     #[error(transparent)]
+    Color(#[from] ParseColorError),
+
+    #[error(transparent)]
     Cryptography(#[from] CryptographyError),
 
     #[error("Decompression error: {}", _0)]
@@ -315,6 +318,10 @@ pub enum XmlParseError {
     #[error("Unexpected end of XML document")]
     Eof,
 }
+
+#[derive(Debug, Error)]
+#[error("Cannot parse color: '{}'", _0)]
+pub struct ParseColorError(pub String);
 
 // move error type conversions to a module and exclude them from coverage counting.
 #[cfg(not(tarpaulin_include))]

--- a/src/xml_db/dump/mod.rs
+++ b/src/xml_db/dump/mod.rs
@@ -13,7 +13,7 @@ use xml::{
 
 use crate::{
     crypt::ciphers::Cipher,
-    db::{CustomData, CustomDataItem, Database, DeletedObject, DeletedObjects, Times},
+    db::{Color, CustomData, CustomDataItem, Database, DeletedObject, DeletedObjects, Times},
     xml_db::get_epoch_baseline,
 };
 
@@ -122,6 +122,16 @@ impl DumpXml for &Uuid {
     ) -> Result<(), xml::writer::Error> {
         let b64 = base64_engine::STANDARD.encode(self.as_bytes());
         writer.write(WriterEvent::Characters(&b64))
+    }
+}
+
+impl DumpXml for &Color {
+    fn dump_xml<E: std::io::Write>(
+        &self,
+        writer: &mut EventWriter<E>,
+        _inner_cipher: &mut dyn Cipher,
+    ) -> Result<(), xml::writer::Error> {
+        writer.write(WriterEvent::Characters(&self.to_string()))
     }
 }
 

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -88,8 +88,8 @@ mod tests {
         entry.icon_id = Some(123);
         entry.custom_icon_uuid = Some(uuid!("22222222222222222222222222222222"));
 
-        entry.foreground_color = Some("#C0FFEE".to_string());
-        entry.background_color = Some("#1C1357".to_string());
+        entry.foreground_color = Some("#C0FFEE".parse().unwrap());
+        entry.background_color = Some("#1C1357".parse().unwrap());
 
         entry.override_url = Some("https://docs.rs/keepass-rs/".to_string());
         entry.quality_check = Some(true);
@@ -186,7 +186,7 @@ mod tests {
             default_username: Some("test-default-username".to_string()),
             default_username_changed: Some("2000-12-31T12:34:58".parse().unwrap()),
             maintenance_history_days: Some(123),
-            color: Some("#C0FFEE".to_string()),
+            color: Some("#C0FFEE".parse().unwrap()),
             master_key_changed: Some("2000-12-31T12:34:59".parse().unwrap()),
             master_key_change_rec: Some(-1),
             master_key_change_force: Some(42),

--- a/src/xml_db/parse/entry.rs
+++ b/src/xml_db/parse/entry.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::{
     crypt::ciphers::Cipher,
-    db::{AutoType, AutoTypeAssociation, Entry, History, Times, Value},
+    db::{AutoType, AutoTypeAssociation, Color, Entry, History, Times, Value},
     xml_db::parse::{CustomData, FromXml, SimpleTag, SimpleXmlEvent, XmlParseError},
 };
 
@@ -75,11 +75,11 @@ impl FromXml for Entry {
                     }
                     "ForegroundColor" => {
                         out.foreground_color =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                            SimpleTag::<Option<Color>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "BackgroundColor" => {
                         out.background_color =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                            SimpleTag::<Option<Color>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "OverrideURL" => {
                         out.override_url =

--- a/src/xml_db/parse/meta.rs
+++ b/src/xml_db/parse/meta.rs
@@ -4,7 +4,10 @@ use uuid::Uuid;
 
 use crate::{
     compression::{Compression, GZipCompression},
-    db::meta::{BinaryAttachment, BinaryAttachments, CustomIcons, Icon, MemoryProtection, Meta},
+    db::{
+        meta::{BinaryAttachment, BinaryAttachments, CustomIcons, Icon, MemoryProtection, Meta},
+        Color,
+    },
     xml_db::parse::{CustomData, FromXml, SimpleTag, SimpleXmlEvent, XmlParseError},
 };
 
@@ -67,7 +70,7 @@ impl FromXml for Meta {
                     }
                     "Color" => {
                         out.color =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                            SimpleTag::<Option<Color>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "MasterKeyChanged" => {
                         out.master_key_changed =

--- a/src/xml_db/parse/mod.rs
+++ b/src/xml_db/parse/mod.rs
@@ -11,7 +11,9 @@ use xml::{name::OwnedName, reader::XmlEvent, EventReader};
 
 use crate::{
     crypt::ciphers::Cipher,
-    db::{CustomData, CustomDataItem, DeletedObject, DeletedObjects, Group, Meta, Times, Value},
+    db::{
+        Color, CustomData, CustomDataItem, DeletedObject, DeletedObjects, Group, Meta, Times, Value,
+    },
     error::XmlParseError,
     xml_db::get_epoch_baseline,
 };
@@ -182,6 +184,12 @@ impl FromXmlCharacters for Uuid {
         let v = base64_engine::STANDARD.decode(s)?;
         let uuid = Uuid::from_slice(&v)?;
         Ok(uuid)
+    }
+}
+
+impl FromXmlCharacters for Color {
+    fn from_xml_characters(s: &str) -> Result<Self, XmlParseError> {
+        Ok(s.parse()?)
     }
 }
 


### PR DESCRIPTION
Instead of storing raw hex strings, create a Color struct and implement parsing and dumping for that.

BREAKING CHANGE: Color fields are not Strings, but Color values now.