### PR TITLE
docs: remove duplicate doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ fn main() -> Result<()> {
 
 ```
 
-## [Documentation](https://docs.rs/keepass)
-
 ## Developer Tools
 This crate also contains several command line tools that can be enabled with feature flags. See the `[[bin]]` sections in [Cargo.toml](Cargo.toml) for a complete list.
 


### PR DESCRIPTION
We already have a badge that links to the documentation, so this header is superfluous.