### PR TITLE
docs: group the usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@
 
 Rust KeePass database file parser for KDB, KDBX3 and KDBX4, with experimental support for KDBX4 writing.
 
-## Example
+## Usage
+<details>
+<summary>
+
+### Open a database
+</summary>
+
 ```rust
 use anyhow::Result;
 use keepass::{
@@ -44,39 +50,14 @@ fn main() -> Result<()> {
     Ok(())
 }
 ```
+</details>
 
-## Installation
-Add the following to the `dependencies` section of your `Cargo.toml`:
+<details>
+<summary>
 
-```ignore
-[dependencies]
-keepass = "*" # TODO replace with current version
-```
+### Save a KDBX4 database (EXPERIMENTAL)
 
-### Performance Notes
-
-Please set the `RUSTFLAGS` environment variable when compiling to enable CPU-specific optimizations (this greatly affects the speed of the AES key derivation):
-
-```bash
-export RUSTFLAGS='-C target-cpu=native'
-```
-
-For best results, also compile in Release mode.
-
-Alternatively, you can add a `.cargo/config.toml` like in this project to ensure that rustflags are always set.
-
-#### For AArch64 / ARMv8:
-
-The `aes` optimizations are not yet enabled on stable rust. If you want a big performance boost you can build using nightly and enabling the `armv8` feature of the `aes` crate:
-
-```ignore
-[dependencies.aes]
-# Needs at least 0.7.5 for the feature
-version = "0.7.5"
-features = ["armv8"]
-```
-
-### EXPERIMENTAL: KDBX 4 database saving
+</summary>
 
 **IMPORTANT:** The inner XML data structure will be re-written from scratch from the internal object representation of this crate, so any field that is not parsed by the library will be lost in the written output file! Please make sure to back up your database before trying this feature.
 
@@ -113,16 +94,58 @@ fn main() -> Result<()> {
 
     Ok(())
 }
-
 ```
 
-## Developer Tools
-This crate also contains several command line tools that can be enabled with feature flags. See the `[[bin]]` sections in [Cargo.toml](Cargo.toml) for a complete list.
+</details>
+
+<details>
+<summary>
+
+### Use developer tools
+
+</summary>
+
+This crate contains several command line tools that can be enabled with the `utilities` feature flag.
+See the `[[bin]]` sections in [Cargo.toml](Cargo.toml) for a complete list.
 
 An example command line for running the `kp-dump-xml` command would be:
 
 ```ignore
 cargo run --release --features "utilities" --bin kp-dump-xml -- path/to/database.kdbx
+```
+
+</details>
+
+
+## Installation
+Add the following to the `dependencies` section of your `Cargo.toml`:
+
+```ignore
+[dependencies]
+keepass = "*" # TODO replace with current version
+```
+
+### Performance Notes
+
+Please set the `RUSTFLAGS` environment variable when compiling to enable CPU-specific optimizations (this greatly affects the speed of the AES key derivation):
+
+```bash
+export RUSTFLAGS='-C target-cpu=native'
+```
+
+For best results, also compile in Release mode.
+
+Alternatively, you can add a `.cargo/config.toml` like in this project to ensure that rustflags are always set.
+
+#### For AArch64 / ARMv8:
+
+The `aes` optimizations are not yet enabled on stable rust. If you want a big performance boost you can build using nightly and enabling the `armv8` feature of the `aes` crate:
+
+```ignore
+[dependencies.aes]
+# Needs at least 0.7.5 for the feature
+version = "0.7.5"
+features = ["armv8"]
 ```
 
 ## License


### PR DESCRIPTION
This will group the usage examples in the README and make them foldable, to make sure that the README is easier to scroll through. The result can be seen [here](https://github.com/sseemayer/keepass-rs/blob/db5837b957dc0d7e6305eb1a90b50d76f8c97802/README.md)