### PR TITLE
feat: expose DatabaseVersion

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use hex_literal::hex;
 
 use std::convert::TryFrom;
 
+pub use crate::format::DatabaseVersion;
+
 use crate::{
     compression,
     crypt::{
@@ -13,7 +15,7 @@ use crate::{
         CompressionConfigError, CryptographyError, InnerCipherConfigError, KdfConfigError,
         OuterCipherConfigError,
     },
-    format::{DatabaseVersion, KDBX4_CURRENT_MINOR_VERSION},
+    format::KDBX4_CURRENT_MINOR_VERSION,
     variant_dictionary::VariantDictionary,
 };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -319,6 +319,7 @@ pub enum XmlParseError {
     Eof,
 }
 
+/// Error parsing a color code
 #[derive(Debug, Error)]
 #[error("Cannot parse color: '{}'", _0)]
 pub struct ParseColorError(pub String);

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -79,7 +79,7 @@ impl DatabaseVersion {
         }
     }
 
-    pub fn get_version_header_size() -> usize {
+    pub(crate) fn get_version_header_size() -> usize {
         12
     }
 }


### PR DESCRIPTION
The DatabaseVersion should be part of the public interface since it is part of the DatabaseConfig