### PR TITLE
ci: run code coverage on prs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,15 @@ jobs:
           IFS=$'\n'; for file in $files; do
             rustfmt --check "$file"
           done
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:0.24.0
+      options: --security-opt seccomp=unconfined
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate code coverage
+        run: |
+          cargo tarpaulin --verbose --timeout 120


### PR DESCRIPTION
Fixes https://github.com/sseemayer/keepass-rs/issues/119

This output seen in the PRs is not as explicit as the one we see on merges, but I didn't want to duplicate the `codedov.io` part of the workflow in multiple places. I think having the check is good enough, and we can always look at the details in case the job fails.