### PR TITLE
feat: support entry updates

### DIFF
--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use chrono::NaiveDateTime;
 use secstr::SecStr;
 use uuid::Uuid;
 
@@ -34,8 +35,13 @@ pub struct Entry {
 }
 impl Entry {
     pub fn new() -> Entry {
+        let mut times = Times::default();
+        let now = Times::now();
+        times.set_creation(now);
+        times.set_last_modification(now);
         Entry {
             uuid: Uuid::new_v4(),
+            times,
             ..Default::default()
         }
     }
@@ -110,6 +116,60 @@ impl<'a> Entry {
     pub fn get_url(&'a self) -> Option<&'a str> {
         self.get("URL")
     }
+
+    /// Adds the current version of the entry to the entry's history
+    /// and updates the last modification timestamp.
+    /// The history will only be updated if the entry has
+    /// uncommited changes.
+    ///
+    /// Returns whether or not a new history entry was added.
+    pub fn update_history(&mut self) -> bool {
+        if self.history.is_none() {
+            self.history = Some(History::default());
+        }
+
+        if !self.has_uncommited_changes() {
+            return false;
+        }
+
+        let mut new_history_entry = self.clone();
+        new_history_entry.history.take().unwrap();
+
+        // TODO should we validate that the history is enabled?
+        // TODO should we validate the maximum size of the history?
+        self.history.as_mut().unwrap().add_entry(new_history_entry);
+
+        self.times
+            .set_last_modification(chrono::Utc::now().naive_utc());
+        true
+    }
+
+    /// Determines if the entry was modified since the last
+    /// history update.
+    fn has_uncommited_changes(&self) -> bool {
+        if let Some(history) = self.history.as_ref() {
+            if history.entries.len() == 0 {
+                return true;
+            }
+
+            let mut sanitized_entry = self.clone();
+            sanitized_entry
+                .times
+                .set_last_modification(NaiveDateTime::default());
+            sanitized_entry.history.take();
+
+            let mut last_history_entry = history.entries.get(0).unwrap().clone();
+            last_history_entry
+                .times
+                .set_last_modification(NaiveDateTime::default());
+            last_history_entry.history.take();
+
+            if sanitized_entry.eq(&last_history_entry) {
+                return false;
+            }
+        }
+        true
+    }
 }
 
 /// A value that can be a raw string, byte array, or protected memory region
@@ -169,6 +229,16 @@ pub struct AutoTypeAssociation {
 pub struct History {
     pub entries: Vec<Entry>,
 }
+impl History {
+    pub fn add_entry(&mut self, mut entry: Entry) {
+        if entry.history.is_some() {
+            // Remove the history from the new history entry to avoid having
+            // an exponential number of history entries.
+            entry.history.take().unwrap();
+        }
+        self.entries.insert(0, entry);
+    }
+}
 
 #[cfg(test)]
 mod entry_tests {
@@ -200,6 +270,87 @@ mod entry_tests {
         assert_eq!(entry.get("a-bytes"), None);
 
         assert_eq!(entry.fields["a-bytes"].is_empty(), false);
+    }
+
+    #[test]
+    fn update_history() {
+        let mut entry = Entry::new();
+        let mut last_modification_time = entry.times.get_last_modification().unwrap().clone();
+
+        entry.fields.insert(
+            "Username".to_string(),
+            Value::Unprotected("user".to_string()),
+        );
+
+        assert!(entry.update_history());
+        assert!(entry.history.is_some());
+        assert_eq!(entry.history.as_ref().unwrap().entries.len(), 1);
+        assert_ne!(
+            entry.times.get_last_modification().unwrap(),
+            &last_modification_time
+        );
+        last_modification_time = entry.times.get_last_modification().unwrap().clone();
+
+        // Updating the history without making any changes
+        // should not do anything.
+        assert!(!entry.update_history());
+        assert!(entry.history.is_some());
+        assert_eq!(entry.history.as_ref().unwrap().entries.len(), 1);
+        assert_eq!(
+            entry.times.get_last_modification().unwrap(),
+            &last_modification_time
+        );
+
+        entry.fields.insert(
+            "Title".to_string(),
+            Value::Unprotected("first title".to_string()),
+        );
+
+        assert!(entry.update_history());
+        assert!(entry.history.is_some());
+        assert_eq!(entry.history.as_ref().unwrap().entries.len(), 2);
+        assert_ne!(
+            entry.times.get_last_modification().unwrap(),
+            &last_modification_time
+        );
+        last_modification_time = entry.times.get_last_modification().unwrap().clone();
+
+        assert!(!entry.update_history());
+        assert!(entry.history.is_some());
+        assert_eq!(entry.history.as_ref().unwrap().entries.len(), 2);
+        assert_eq!(
+            entry.times.get_last_modification().unwrap(),
+            &last_modification_time
+        );
+
+        entry.fields.insert(
+            "Title".to_string(),
+            Value::Unprotected("second title".to_string()),
+        );
+
+        assert!(entry.update_history());
+        assert!(entry.history.is_some());
+        assert_eq!(entry.history.as_ref().unwrap().entries.len(), 3);
+        assert_ne!(
+            entry.times.get_last_modification().unwrap(),
+            &last_modification_time
+        );
+        last_modification_time = entry.times.get_last_modification().unwrap().clone();
+
+        assert!(!entry.update_history());
+        assert!(entry.history.is_some());
+        assert_eq!(entry.history.as_ref().unwrap().entries.len(), 3);
+        assert_eq!(
+            entry.times.get_last_modification().unwrap(),
+            &last_modification_time
+        );
+
+        let last_history_entry = entry.history.as_ref().unwrap().entries.get(0).unwrap();
+        assert_eq!(last_history_entry.get_title().unwrap(), "second title");
+
+        for history_entry in &entry.history.unwrap().entries {
+            assert!(history_entry.history.is_none());
+        }
     }
 
     #[cfg(feature = "totp")]

--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -54,8 +54,13 @@ pub struct Group {
 
 impl Group {
     pub fn new(name: &str) -> Group {
+        let mut times = Times::default();
+        let now = Times::now();
+        times.set_creation(now);
+        times.set_last_modification(now);
         Group {
             name: name.to_string(),
+            times,
             uuid: Uuid::new_v4(),
             ..Default::default()
         }


### PR DESCRIPTION
This PR adds an `Entry` function to commit changes to the history and to update the modification timestamp. This new function also encapsulates some expectations about the history, like the fact that recursive entry histories should not be allowed.