### PR TITLE
feat: implement default time values

### DIFF
--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -74,10 +74,10 @@ impl<'a> Entry {
         self.times.get(key)
     }
 
-    /// Convenience method for getting the value of the 'ExpiryTime' timestamp
+    /// Convenience method for getting the time that the entry expires.
     /// This value is usually only meaningful/useful when expires == true
     pub fn get_expiry_time(&self) -> Option<&chrono::NaiveDateTime> {
-        self.get_time("ExpiryTime")
+        self.times.get_expiry()
     }
 
     /// Convenience method for getting a TOTP from this entry

--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -143,9 +143,9 @@ impl Group {
         self.times.get(key)
     }
 
-    /// Convenience method for getting the value of the 'ExpiryTime' timestamp
+    /// Convenience method for getting the time that the group expires
     pub fn get_expiry_time(&self) -> Option<&chrono::NaiveDateTime> {
-        self.get_time("ExpiryTime")
+        self.times.get_expiry()
     }
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -157,9 +157,65 @@ pub struct Times {
     pub times: HashMap<String, NaiveDateTime>,
 }
 
+pub const EXPIRY_TIME_TAG_NAME: &str = "ExpiryTime";
+pub const LAST_MODIFICATION_TIME_TAG_NAME: &str = "LastModificationTime";
+pub const CREATION_TIME_TAG_NAME: &str = "CreationTime";
+pub const LAST_ACCESS_TIME_TAG_NAME: &str = "LastAccessTime";
+pub const LOCATION_CHANGED_TAG_NAME: &str = "LocationChanged";
+
 impl Times {
     fn get(&self, key: &str) -> Option<&NaiveDateTime> {
         self.times.get(key)
+    }
+
+    pub fn get_expiry(&self) -> Option<&NaiveDateTime> {
+        self.times.get(EXPIRY_TIME_TAG_NAME)
+    }
+
+    pub fn set_expiry(&mut self, time: NaiveDateTime) {
+        self.times.insert(EXPIRY_TIME_TAG_NAME.to_string(), time);
+    }
+
+    pub fn get_last_modification(&self) -> Option<&NaiveDateTime> {
+        self.times.get(LAST_MODIFICATION_TIME_TAG_NAME)
+    }
+
+    pub fn set_last_modification(&mut self, time: NaiveDateTime) {
+        self.times
+            .insert(LAST_MODIFICATION_TIME_TAG_NAME.to_string(), time);
+    }
+
+    pub fn get_creation(&self) -> Option<&NaiveDateTime> {
+        self.times.get(CREATION_TIME_TAG_NAME)
+    }
+
+    pub fn set_creation(&mut self, time: NaiveDateTime) {
+        self.times.insert(CREATION_TIME_TAG_NAME.to_string(), time);
+    }
+
+    pub fn get_last_access(&self) -> Option<&NaiveDateTime> {
+        self.times.get(LAST_ACCESS_TIME_TAG_NAME)
+    }
+
+    pub fn set_last_access(&mut self, time: NaiveDateTime) {
+        self.times
+            .insert(LAST_ACCESS_TIME_TAG_NAME.to_string(), time);
+    }
+
+    pub fn get_location_changed(&self) -> Option<&NaiveDateTime> {
+        self.times.get(LOCATION_CHANGED_TAG_NAME)
+    }
+
+    pub fn set_location_changed(&mut self, time: NaiveDateTime) {
+        self.times
+            .insert(LOCATION_CHANGED_TAG_NAME.to_string(), time);
+    }
+
+    // Returns the current time, without the nanoseconds since
+    // the last leap second.
+    pub fn now() -> NaiveDateTime {
+        let now = chrono::Utc::now().naive_utc().timestamp();
+        chrono::NaiveDateTime::from_timestamp_opt(now, 0).unwrap()
     }
 }
 

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -19,7 +19,7 @@ mod tests {
             entry::History,
             meta::{BinaryAttachments, CustomIcons, Icon, MemoryProtection},
             AutoType, AutoTypeAssociation, BinaryAttachment, CustomData, CustomDataItem, Database,
-            DeletedObject, Entry, Group, Meta, Node, Value,
+            DeletedObject, Entry, Group, Meta, Node, Times, Value,
         },
         format::kdbx4,
         key::DatabaseKey,
@@ -60,10 +60,12 @@ mod tests {
         entry.tags.push("keepass-rs".to_string());
         entry.times.expires = true;
         entry.times.usage_count = 42;
-        entry
-            .times
-            .times
-            .insert("Created".to_string(), NaiveDateTime::default());
+        entry.times.set_creation(NaiveDateTime::default());
+        entry.times.set_expiry(NaiveDateTime::default());
+        entry.times.set_last_access(NaiveDateTime::default());
+        entry.times.set_location_changed(Times::now());
+        entry.times.set_last_modification(Times::now());
+
         entry.autotype = Some(AutoType {
             enabled: true,
             sequence: Some("Autotype-sequence".to_string()),
@@ -137,10 +139,11 @@ mod tests {
         subgroup.custom_icon_uuid = Some(uuid!("11111111111111111111111111111111"));
         subgroup.times.expires = true;
         subgroup.times.usage_count = 100;
-        subgroup
-            .times
-            .times
-            .insert("Created".to_string(), NaiveDateTime::default());
+        subgroup.times.set_creation(NaiveDateTime::default());
+        subgroup.times.set_expiry(NaiveDateTime::default());
+        subgroup.times.set_last_access(NaiveDateTime::default());
+        subgroup.times.set_location_changed(Times::now());
+        subgroup.times.set_last_modification(Times::now());
         subgroup.is_expanded = true;
         subgroup.default_autotype_sequence =
             Some("{UP}{UP}{DOWN}{DOWN}{LEFT}{RIGHT}{LEFT}{RIGHT}BA".to_string());


### PR DESCRIPTION
This PR implements the default time values that are stored in KDBX databases. I had to create a `now()` method because by default the `NaiveDateTime` will be created with the nanoseconds since the last leap second, which will not be preserved when dumping and parsing the database. This would result in the `test_entry` and `test_group` tests failing.