### PR TITLE
refactor: make history entries read-only

### DIFF
--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -227,7 +227,7 @@ pub struct AutoTypeAssociation {
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct History {
-    pub entries: Vec<Entry>,
+    pub(crate) entries: Vec<Entry>,
 }
 impl History {
     pub fn add_entry(&mut self, mut entry: Entry) {
@@ -237,6 +237,10 @@ impl History {
             entry.history.take().unwrap();
         }
         self.entries.insert(0, entry);
+    }
+
+    pub fn get_entries(&self) -> &Vec<Entry> {
+        &self.entries
     }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: the `entries` field of the `History` struct is no longer accessible directly. The
`get_entries` function can instead be used to return a read-only reference to the entries. This is to
prevent the history entries from containing recursive history entries, which would prevent the database
from being opened by other applications like KeePassXC.