### PR TITLE
fix: set all default times when creating a node

### DIFF
--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -35,13 +35,9 @@ pub struct Entry {
 }
 impl Entry {
     pub fn new() -> Entry {
-        let mut times = Times::default();
-        let now = Times::now();
-        times.set_creation(now);
-        times.set_last_modification(now);
         Entry {
             uuid: Uuid::new_v4(),
-            times,
+            times: Times::new(),
             ..Default::default()
         }
     }

--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -54,13 +54,9 @@ pub struct Group {
 
 impl Group {
     pub fn new(name: &str) -> Group {
-        let mut times = Times::default();
-        let now = Times::now();
-        times.set_creation(now);
-        times.set_last_modification(now);
         Group {
             name: name.to_string(),
-            times,
+            times: Times::new(),
             uuid: Uuid::new_v4(),
             ..Default::default()
         }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -217,6 +217,18 @@ impl Times {
         let now = chrono::Utc::now().naive_utc().timestamp();
         chrono::NaiveDateTime::from_timestamp_opt(now, 0).unwrap()
     }
+
+    pub fn new() -> Times {
+        let mut response = Times::default();
+        let now = Times::now();
+        response.set_creation(now);
+        response.set_last_modification(now);
+        response.set_last_access(now);
+        response.set_location_changed(now);
+        response.set_expiry(now);
+        response.expires = false;
+        response
+    }
 }
 
 /// Collection of custom data fields for an entry or metadata


### PR DESCRIPTION
Other KDBX parsers (like the one in KeePassXC)
store all the default times as fields of a class,
instead of items in a map. The result is that
default times that are not populated will be
given a default value at parsing time. This can
result in drift between an entry and its history items,
as described in https://github.com/sseemayer/keepass-rs/issues/153.
Populating all the default times is thus safer
for interoperability between KDBX4 parsers.