### PR TITLE
ci: use the master ci for build status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ---
-name: CI
+name: CI on Pull Requests
 
 on:
   pull_request:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,5 +1,5 @@
 ---
-name: Merge on Master
+name: CI on Master
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/keepass.svg)](https://crates.io/crates/keepass)
 [![Documentation](https://docs.rs/keepass/badge.svg)](https://docs.rs/keepass/)
-[![Build Status](https://github.com/sseemayer/keepass-rs/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/sseemayer/keepass-rs/actions/workflows/ci.yml)
+[![Build Status](https://github.com/sseemayer/keepass-rs/actions/workflows/merge.yml/badge.svg?branch=master)](https://github.com/sseemayer/keepass-rs/actions/workflows/merge.yml)
 [![codecov](https://codecov.io/gh/sseemayer/keepass-rs/branch/master/graph/badge.svg)](https://codecov.io/gh/sseemayer/keepass-rs)
 [![dependency status](https://deps.rs/repo/github/sseemayer/keepass-rs/status.svg)](https://deps.rs/repo/github/sseemayer/keepass-rs)
 [![License file](https://img.shields.io/github/license/sseemayer/keepass-rs)](https://github.com/sseemayer/keepass-rs/blob/master/LICENSE)


### PR DESCRIPTION
The build status badge in the README was targeting the `ci` job, which is only running on pull requests. We used to run the `ci` workflow on the master branch, which is why the build status was marked as passing, but those workflow runs were 2 months old.