### PR TITLE
ci: fix the docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,21 @@ jobs:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v5
 
+  doc:
+    name: Build Doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - name: run cargo doc
+        run: cargo doc
+
   check:
     name: Check
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ clap = { version = "4", optional = true, features = ["derive"] }
 rpassword = { version = "7", optional = true }
 
 # dependencies for serialization (enabled by "serialization" feature)
-serde = { version = "1", optional = true }
+serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }
 
 # dependencies for totp (enabled by "totp" feature)
@@ -62,6 +62,7 @@ totp-lite = { version = "2.0.0", optional = true }
 url = { version = "2.2.2", optional = true }
 base32 = { version = "0.4.0", optional = true }
 
+[dev-dependencies]
 rustfmt = "0.10.0"
 
 [[bin]]


### PR DESCRIPTION
The build for the docs was failing, as can be seen in the logs [here](https://docs.rs/crate/keepass/0.6.0/builds/770101). The issue was related to `rustfmt`, which is only a dev dependency, so I marked it as such. I think we were relying on `rustfmt` using the `derive` feature of serde, because the builds started failing after that. I enabled the `derive` feature explicitly to resolve the issue.

When this is merged, we will need to publish a new version in order to update the crates.io doc to the latest version.