### PR TITLE
fix: CustomData changes

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -235,16 +235,23 @@ impl Times {
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct CustomData {
-    pub items: Vec<CustomDataItem>,
+    pub items: HashMap<String, CustomDataItem>,
 }
 
-/// Custom data field for an entry or metadata
+/// Custom data field for an entry or metadata for internal use
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct CustomDataItem {
-    pub key: String,
     pub value: Option<Value>,
     pub last_modification_time: Option<NaiveDateTime>,
+}
+
+/// Custom data field for an entry or metadata from XML data
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+pub struct CustomDataItemDenormalized {
+    pub key: String,
+    pub custom_data_item: CustomDataItem,
 }
 
 /// Binary attachments stored in a database inner header

--- a/src/xml_db/dump/mod.rs
+++ b/src/xml_db/dump/mod.rs
@@ -203,8 +203,13 @@ impl DumpXml for CustomData {
     ) -> Result<(), xml::writer::Error> {
         writer.write(WriterEvent::start_element("CustomData"))?;
 
-        for item in &self.items {
+        for (key, item) in &self.items {
+            writer.write(WriterEvent::start_element("Item"))?;
+
+            SimpleTag("Key", key).dump_xml(writer, inner_cipher)?;
             item.dump_xml(writer, inner_cipher)?;
+
+            writer.write(WriterEvent::end_element())?;
         }
 
         writer.write(WriterEvent::end_element())?;
@@ -219,10 +224,6 @@ impl DumpXml for CustomDataItem {
         writer: &mut EventWriter<E>,
         inner_cipher: &mut dyn Cipher,
     ) -> Result<(), xml::writer::Error> {
-        writer.write(WriterEvent::start_element("Item"))?;
-
-        SimpleTag("Key", &self.key).dump_xml(writer, inner_cipher)?;
-
         if let Some(ref value) = self.value {
             value.dump_xml(writer, inner_cipher)?;
         }
@@ -231,7 +232,6 @@ impl DumpXml for CustomDataItem {
             SimpleTag("LastModificationTime", value).dump_xml(writer, inner_cipher)?;
         }
 
-        writer.write(WriterEvent::end_element())?;
         Ok(())
     }
 }

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -11,6 +11,7 @@ pub fn get_epoch_baseline() -> chrono::NaiveDateTime {
 mod tests {
     use chrono::NaiveDateTime;
     use secstr::SecStr;
+    use std::collections::HashMap;
     use uuid::uuid;
 
     use crate::{
@@ -81,11 +82,13 @@ mod tests {
             ],
         });
 
-        entry.custom_data.items.push(CustomDataItem {
-            key: "CDI-key".to_string(),
-            value: Some(Value::Unprotected("CDI-Value".to_string())),
-            last_modification_time: Some(NaiveDateTime::default()),
-        });
+        entry.custom_data.items.insert(
+            "CDI-key".to_string(),
+            CustomDataItem {
+                value: Some(Value::Unprotected("CDI-Value".to_string())),
+                last_modification_time: Some(NaiveDateTime::default()),
+            },
+        );
 
         entry.icon_id = Some(123);
         entry.custom_icon_uuid = Some(uuid!("22222222222222222222222222222222"));
@@ -152,11 +155,13 @@ mod tests {
 
         subgroup.last_top_visible_entry = Some(uuid!("43210000000000000000000000000000"));
 
-        subgroup.custom_data.items.push(CustomDataItem {
-            key: "CustomOption".to_string(),
-            value: Some(Value::Unprotected("CustomOption-Value".to_string())),
-            last_modification_time: Some(NaiveDateTime::default()),
-        });
+        subgroup.custom_data.items.insert(
+            "CustomOption".to_string(),
+            CustomDataItem {
+                value: Some(Value::Unprotected("CustomOption-Value".to_string())),
+                last_modification_time: Some(NaiveDateTime::default()),
+            },
+        );
 
         root_group.children.push(Node::Group(subgroup));
 
@@ -242,23 +247,31 @@ mod tests {
                 ],
             },
             custom_data: CustomData {
-                items: vec![
-                    CustomDataItem {
-                        key: "custom-data-key".to_string(),
-                        value: Some(Value::Unprotected("custom-data-value".to_string())),
-                        last_modification_time: Some("2000-12-31T12:35:03".parse().unwrap()),
-                    },
-                    CustomDataItem {
-                        key: "custom-data-key-without-value".to_string(),
-                        value: None,
-                        last_modification_time: None,
-                    },
-                    CustomDataItem {
-                        key: "custom-data-protected-key".to_string(),
-                        value: Some(Value::Protected(SecStr::new(b"custom-data-value".to_vec()))),
-                        last_modification_time: Some("2000-12-31T12:35:03".parse().unwrap()),
-                    },
-                ],
+                items: HashMap::from([
+                    (
+                        "custom-data-key".to_string(),
+                        CustomDataItem {
+                            value: Some(Value::Unprotected("custom-data-value".to_string())),
+                            last_modification_time: Some("2000-12-31T12:35:03".parse().unwrap()),
+                        },
+                    ),
+                    (
+                        "custom-data-key-without-value".to_string(),
+                        CustomDataItem {
+                            value: None,
+                            last_modification_time: None,
+                        },
+                    ),
+                    (
+                        "custom-data-protected-key".to_string(),
+                        CustomDataItem {
+                            value: Some(Value::Protected(SecStr::new(
+                                b"custom-data-value".to_vec(),
+                            ))),
+                            last_modification_time: Some("2000-12-31T12:35:03".parse().unwrap()),
+                        },
+                    ),
+                ]),
             },
         };
 


### PR DESCRIPTION
The CustomData in KeePassXC is handled as a hashmap, and it should processed in a similar way. Without the hashmap own iterators, setters and getters should be implemented instead of just using `.contains_key()` etc. directly. I was tempted to remove the `items` inside the `CustomData` so it could be just a define for the `HashMap<String, CustomDataItem>` but leaving as it is enabled some custom implementations for it in the future.

CustomData is now added to the Group too.

Downside of this change is that another struct is needed when parsing the data from XML because there the `<Item>` includes also the key. When dumping the data it has to make sure everything is put inside an `<Item>` again.

Some things I noticed while writing new tests. Should the parsing/dumping also handle situations where the key doesn't exist? For example the following tests are not working nicely if some incorrect data has been entered:
```
 // For fields
parse_test_xml::<SimpleTag<String>>("<TestTag>42</TestTag>");
// For CustomData
parse_test_xml::<CustomDataItemFromXml>("<Item><Value>NoKey</Value><LastModificationTime>1234</LastModificationTime></Item>");
```

Any suggestions are welcome.