### PR TITLE
feat(deps): bump hex-literal to 0.4.X

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ byteorder = "1"
 flate2 = "1"
 xml-rs = "0.8"
 base64 = "0.21"
-hex-literal = "0.3"
+hex-literal = "0.4"
 secstr = "0.5"
 chrono = "0.4.23"
 


### PR DESCRIPTION
This will fix the `out of date` warning currently displayed [on deps.rs](https://deps.rs/repo/github/sseemayer/keepass-rs)