### PR TITLE
Update chrono dependency due to RUSTSEC-2020-0071

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,11 @@ xml-rs = "0.8"
 base64 = "0.21"
 hex-literal = "0.4"
 secstr = "0.5"
-chrono = "0.4.23"
+chrono = { version = "0.4.23", default-features = false, features = [
+    "serde",
+    "clock",
+    "std",
+] }
 
 # cryptography
 rust-argon2 = "1.0"


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2020-0071

Workarounds

A possible workaround for crates affected through the transitive dependency in chrono, is to avoid using the default oldtime feature dependency of the chrono crate by disabling its default-features and manually specifying the required features instead.