### PR TITLE
refactor(key)!: use a builder-like pattern and owned internal representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,10 @@ use keepass::{
 use std::fs::File;
 
 fn main() -> Result<(), DatabaseOpenError> {
-    // Open KeePass database
-    let path = std::path::Path::new("tests/resources/test_db_with_password.kdbx");
-    let db = Database::open(
-        &mut File::open(path)?,                 // the database
-        DatabaseKey::with_password("demopass"), // password (keyfile is also supported)
-    )?;
+    // Open KeePass database using a password (keyfile is also supported)
+    let mut file = File::open("tests/resources/test_db_with_password.kdbx")?;
+    let key = DatabaseKey::new().with_password("demopass");
+    let db = Database::open(&mut file, key)?;
 
     // Iterate over all `Group`s and `Entry`s
     for node in &db.root {
@@ -90,7 +88,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "save_kdbx4")]
     db.save(
         &mut File::create("demo.kdbx")?,
-        DatabaseKey::with_password("demopass"),
+        DatabaseKey::new().with_password("demopass"),
     )?;
 
     Ok(())

--- a/src/bin/kp-dump-json.rs
+++ b/src/bin/kp-dump-json.rs
@@ -1,5 +1,5 @@
 /// utility to dump keepass database as JSON document
-use std::{fs::File, io::Read};
+use std::fs::File;
 
 use anyhow::Result;
 use clap::Parser;
@@ -21,20 +21,20 @@ pub fn main() -> Result<()> {
     let args = Args::parse();
 
     let mut source = File::open(args.in_kdbx)?;
-    let mut keyfile: Option<File> = args.keyfile.and_then(|f| File::open(f).ok());
+    let mut key = DatabaseKey::new();
+
+    if let Some(f) = args.keyfile {
+        key = key.with_keyfile(&mut File::open(f)?)?;
+    }
 
     let password =
         rpassword::prompt_password("Password (or blank for none): ").expect("Read password");
 
-    let password = if password.is_empty() {
-        None
-    } else {
-        Some(&password[..])
+    if !password.is_empty() {
+        key = key.with_password(&password);
     };
 
-    let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
-
-    let db = Database::open(&mut source, DatabaseKey::new(password, keyfile))?;
+    let db = Database::open(&mut source, key)?;
 
     let stdout = std::io::stdout().lock();
     serde_json::ser::to_writer(stdout, &db)?;

--- a/src/bin/kp-dump-json.rs
+++ b/src/bin/kp-dump-json.rs
@@ -34,7 +34,7 @@ pub fn main() -> Result<()> {
 
     let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
 
-    let db = Database::open(&mut source, DatabaseKey { password, keyfile })?;
+    let db = Database::open(&mut source, DatabaseKey::new(password, keyfile))?;
 
     let stdout = std::io::stdout().lock();
     serde_json::ser::to_writer(stdout, &db)?;

--- a/src/bin/kp-dump-xml.rs
+++ b/src/bin/kp-dump-xml.rs
@@ -38,7 +38,7 @@ pub fn main() -> Result<()> {
 
     let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
 
-    let xml = Database::get_xml(&mut source, DatabaseKey { password, keyfile })?;
+    let xml = Database::get_xml(&mut source, DatabaseKey::new(password, keyfile))?;
 
     File::create(args.out_xml)?.write_all(&xml)?;
 

--- a/src/bin/kp-dump-xml.rs
+++ b/src/bin/kp-dump-xml.rs
@@ -1,6 +1,6 @@
 /// utility to dump keepass database internal XML data.
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 
 use anyhow::Result;
 use clap::Parser;
@@ -25,20 +25,20 @@ pub fn main() -> Result<()> {
     let args = Args::parse();
 
     let mut source = File::open(args.in_kdbx)?;
-    let mut keyfile: Option<File> = args.keyfile.and_then(|f| File::open(f).ok());
+    let mut key = DatabaseKey::new();
 
-    let password = rpassword::prompt_password("Password (or blank for none): ")
-        .expect("Could not read password from TTY");
+    if let Some(f) = args.keyfile {
+        key = key.with_keyfile(&mut File::open(f)?)?;
+    }
 
-    let password = if password.is_empty() {
-        None
-    } else {
-        Some(&password[..])
+    let password =
+        rpassword::prompt_password("Password (or blank for none): ").expect("Read password");
+
+    if !password.is_empty() {
+        key = key.with_password(&password);
     };
 
-    let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
-
-    let xml = Database::get_xml(&mut source, DatabaseKey::new(password, keyfile))?;
+    let xml = Database::get_xml(&mut source, key)?;
 
     File::create(args.out_xml)?.write_all(&xml)?;
 

--- a/src/bin/kp-rewrite.rs
+++ b/src/bin/kp-rewrite.rs
@@ -44,21 +44,12 @@ pub fn main() -> Result<()> {
         None
     };
 
-    let db = Database::open(
-        &mut source,
-        DatabaseKey {
-            password,
-            keyfile: keyfile.as_mut().map(|kf| kf as &mut dyn Read),
-        },
-    )?;
+    let kf = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
+    let db = Database::open(&mut source, DatabaseKey::new(password, kf))?;
 
-    db.save(
-        &mut File::create(args.out_kdbx)?,
-        DatabaseKey {
-            password,
-            keyfile: keyfile.as_mut().map(|kf| kf as &mut dyn Read),
-        },
-    )?;
+    let mut out_file = File::create(args.out_kdbx)?;
+    let kf = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
+    db.save(&mut out_file, DatabaseKey::new(password, kf))?;
 
     Ok(())
 }

--- a/src/bin/kp-show-db.rs
+++ b/src/bin/kp-show-db.rs
@@ -35,7 +35,7 @@ pub fn main() -> Result<()> {
 
     let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
 
-    let db = Database::open(&mut source, DatabaseKey { password, keyfile })?;
+    let db = Database::open(&mut source, DatabaseKey::new(password, keyfile))?;
 
     println!("{:#?}", db);
 

--- a/src/bin/kp-show-otp.rs
+++ b/src/bin/kp-show-otp.rs
@@ -1,6 +1,5 @@
 /// utility to dump keepass database internal XML data.
 use std::fs::File;
-use std::io::Read;
 
 use anyhow::Result;
 use clap::Parser;
@@ -24,21 +23,20 @@ pub fn main() -> Result<()> {
     let args = Args::parse();
 
     let mut source = File::open(args.in_kdbx)?;
+    let mut key = DatabaseKey::new();
 
-    let mut keyfile: Option<File> = args.keyfile.and_then(|f| File::open(f).ok());
+    if let Some(f) = args.keyfile {
+        key = key.with_keyfile(&mut File::open(f)?)?;
+    }
 
     let password =
         rpassword::prompt_password("Password (or blank for none): ").expect("Read password");
 
-    let password = if password.is_empty() {
-        None
-    } else {
-        Some(&password[..])
+    if !password.is_empty() {
+        key = key.with_password(&password);
     };
 
-    let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
-
-    let db = Database::open(&mut source, DatabaseKey::new(password, keyfile))?;
+    let db = Database::open(&mut source, key)?;
 
     if let Some(NodeRef::Entry(e)) = db.root.get(&[&args.entry]) {
         let totp = e.get_otp().unwrap();

--- a/src/bin/kp-show-otp.rs
+++ b/src/bin/kp-show-otp.rs
@@ -38,7 +38,7 @@ pub fn main() -> Result<()> {
 
     let keyfile = keyfile.as_mut().map(|kf| kf as &mut dyn Read);
 
-    let db = Database::open(&mut source, DatabaseKey { password, keyfile })?;
+    let db = Database::open(&mut source, DatabaseKey::new(password, keyfile))?;
 
     if let Some(NodeRef::Entry(e)) = db.root.get(&[&args.entry]) {
         let totp = e.get_otp().unwrap();

--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -68,12 +68,12 @@ impl Group {
     /// Recursively get a Group or Entry reference by specifying a path relative to the current Group
     /// ```
     /// use keepass::{Database, DatabaseKey, db::NodeRef};
-    /// use std::{fs::File, path::Path};
+    /// use std::fs::File;
     ///
-    /// let path = Path::new("tests/resources/test_db_with_password.kdbx");
+    /// let mut file = File::open("tests/resources/test_db_with_password.kdbx").unwrap();
     /// let db = Database::open(
-    ///     &mut File::open(path).unwrap(),
-    ///     DatabaseKey::with_password("demopass")
+    ///     &mut file,
+    ///     DatabaseKey::new().with_password("demopass")
     /// ).unwrap();
     ///
     /// if let Some(NodeRef::Entry(e)) = db.root.get(&["General", "Sample Entry #2"]) {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -330,7 +330,7 @@ mod database_tests {
     fn test_xml() -> Result<(), DatabaseOpenError> {
         let xml = Database::get_xml(
             &mut File::open("tests/resources/test_db_with_password.kdbx")?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         assert!(xml.len() > 100);
@@ -350,12 +350,12 @@ mod database_tests {
 
         let mut buffer = Vec::new();
 
-        db.save(&mut buffer, DatabaseKey::with_password("testing"))
+        db.save(&mut buffer, DatabaseKey::new().with_password("testing"))
             .unwrap();
 
         let db_loaded = Database::open(
             &mut buffer.as_slice(),
-            DatabaseKey::with_password("testing"),
+            DatabaseKey::new().with_password("testing"),
         )
         .unwrap();
 

--- a/src/db/otp.rs
+++ b/src/db/otp.rs
@@ -177,7 +177,10 @@ mod kdbx4_otp_tests {
     fn kdbx4_entry() -> Result<(), Box<dyn std::error::Error>> {
         // KDBX4 database format Base64 encodes ExpiryTime (and all other XML timestamps)
         let path = Path::new("tests/resources/test_db_kdbx4_with_totp_entry.kdbx");
-        let db = Database::open(&mut File::open(path)?, DatabaseKey::with_password("test"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::new().with_password("test"),
+        )?;
 
         let otp_str = "otpauth://totp/KeePassXC:none?secret=JBSWY3DPEHPK3PXP&period=30&digits=6&issuer=KeePassXC";
 

--- a/src/format/kdbx4/mod.rs
+++ b/src/format/kdbx4/mod.rs
@@ -81,7 +81,8 @@ mod kdbx4_tests {
             password += &std::char::from_u32(random_char as u32).unwrap().to_string();
         }
 
-        let key_elements = DatabaseKey::with_password(&password)
+        let key_elements = DatabaseKey::new()
+            .with_password(&password)
             .get_key_elements()
             .unwrap();
 
@@ -172,7 +173,8 @@ mod kdbx4_tests {
 
         db.root.children.push(Node::Entry(entry));
 
-        let key_elements = DatabaseKey::with_password("test")
+        let key_elements = DatabaseKey::new()
+            .with_password("test")
             .get_key_elements()
             .unwrap();
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -57,8 +57,8 @@ fn parse_keyfile(buffer: &[u8]) -> Result<Vec<u8>, DatabaseKeyError> {
 /// A KeePass key, which might consist of a password and/or a keyfile
 #[derive(Debug, Clone, Default)]
 pub struct DatabaseKey {
-    pub password: Option<String>,
-    pub keyfile: Option<Vec<u8>>,
+    password: Option<String>,
+    keyfile: Option<Vec<u8>>,
 }
 
 impl DatabaseKey {

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -35,7 +35,8 @@ mod tests {
             password += &std::char::from_u32(random_char as u32).unwrap().to_string();
         }
 
-        let key_elements = DatabaseKey::with_password(&password)
+        let key_elements = DatabaseKey::new()
+            .with_password(&password)
             .get_key_elements()
             .unwrap();
         key_elements

--- a/tests/entry_tests.rs
+++ b/tests/entry_tests.rs
@@ -12,7 +12,7 @@ mod entry_tests {
         let path = Path::new("tests/resources/test_db_with_password.kdbx");
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         // get an entry on the root node
@@ -70,7 +70,7 @@ mod entry_tests {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         // get an entry on the root node
@@ -98,7 +98,7 @@ mod entry_tests {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("this password is not correct"),
+            DatabaseKey::new().with_password("this password is not correct"),
         );
 
         assert!(db.is_err());

--- a/tests/file_read_tests.rs
+++ b/tests/file_read_tests.rs
@@ -13,7 +13,7 @@ mod file_read_tests {
         let path = Path::new("tests/resources/test_db_with_password.kdbx");
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -52,7 +52,7 @@ mod file_read_tests {
         let kf_path = Path::new("tests/resources/test_key.key");
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_keyfile(&mut File::open(kf_path)?),
+            DatabaseKey::new().with_keyfile(&mut File::open(kf_path)?)?,
         )?;
 
         println!("{:?} DB Opened", db);
@@ -91,7 +91,7 @@ mod file_read_tests {
         let kf_path = Path::new("tests/resources/test_key_xml.key");
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_keyfile(&mut File::open(kf_path)?),
+            DatabaseKey::new().with_keyfile(&mut File::open(kf_path)?)?,
         )?;
 
         println!("{:?} DB Opened", db);
@@ -130,7 +130,7 @@ mod file_read_tests {
 
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -147,7 +147,7 @@ mod file_read_tests {
 
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -163,7 +163,7 @@ mod file_read_tests {
         let path = Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -180,7 +180,7 @@ mod file_read_tests {
 
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -197,7 +197,7 @@ mod file_read_tests {
 
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -214,7 +214,7 @@ mod file_read_tests {
 
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -231,7 +231,7 @@ mod file_read_tests {
 
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -249,7 +249,7 @@ mod file_read_tests {
 
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_keyfile(&mut File::open(kf_path)?),
+            DatabaseKey::new().with_keyfile(&mut File::open(kf_path)?)?,
         )?;
 
         println!("{:?} DB Opened", db);
@@ -266,7 +266,7 @@ mod file_read_tests {
         let path = Path::new("tests/resources/broken_random_data.kdbx");
         Database::open(
             &mut File::open(path).unwrap(),
-            DatabaseKey::with_password(""),
+            DatabaseKey::new().with_password(""),
         )
         .unwrap();
     }
@@ -277,7 +277,7 @@ mod file_read_tests {
         let path = Path::new("tests/resources/broken_kdbx_version.kdbx");
         Database::open(
             &mut File::open(path).unwrap(),
-            DatabaseKey::with_password(""),
+            DatabaseKey::new().with_password(""),
         )
         .unwrap();
     }
@@ -285,7 +285,10 @@ mod file_read_tests {
     #[test]
     fn open_kdb_with_password() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdb_with_password.kdb");
-        let db = Database::open(&mut File::open(path)?, DatabaseKey::with_password("foobar"))?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::new().with_password("foobar"),
+        )?;
 
         println!("{:?} DB Opened", db);
         assert_eq!(db.root.name, "Root");
@@ -322,7 +325,7 @@ mod file_read_tests {
         let path = Path::new("tests/resources/test_db_kdb3_with_file_larger_1mb.kdbx");
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("samplepassword"),
+            DatabaseKey::new().with_password("samplepassword"),
         )?;
 
         println!("{:?} DB Opened", db);
@@ -359,7 +362,7 @@ mod file_read_tests {
 
         let db = Database::open(
             &mut File::open(path)?,
-            DatabaseKey::with_password("demopass"),
+            DatabaseKey::new().with_password("demopass"),
         )?;
 
         println!("{:?} DB Opened", db);


### PR DESCRIPTION
I think the memory occupied by this structure cannot be very large. For ease of use, it is a good idea to remove its lifetime annotation.