### PR TITLE
fix: group's "get" function not returning groups

### DIFF
--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -87,7 +87,13 @@ impl Group {
             if path.len() == 1 {
                 let head = path[0];
                 self.children.iter().find_map(|n| match n {
-                    Node::Group(_) => None,
+                    Node::Group(g) => {
+                        if g.name == head {
+                            Some(n.as_ref())
+                        } else {
+                            None
+                        }
+                    }
                     Node::Entry(e) => {
                         e.get_title()
                             .and_then(|t| if t == head { Some(n.as_ref()) } else { None })


### PR DESCRIPTION
Issue when using the "get" function to retrieve a group by its path.

Example PoC :
```
    let path = Path::new("tests/resources/test_db_with_password.kdbx");
    let mut db = Database::open(
        &mut File::open(path).unwrap(),
        DatabaseKey::with_password("demopass")
    ).unwrap();
   
    if let Some(NodeRefMut::Group(e)) = db.root.get_mut(&["General"]) {
        println!("Group: {}", e.name);
    }

    // This does not return a group !!!
    if let Some(NodeRef::Group(e)) = db.root.get(&["General"]) {
        println!("Group: {}", e.name);
    }
```



