### PR TITLE
feat: implement From trait for Node types

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     entry.fields.insert("UserName".to_string(), Value::Unprotected("jdoe".to_string()));
     entry.fields.insert("Password".to_string(), Value::Protected("hunter2".as_bytes().into()));
 
-    group.children.push(Node::Entry(entry));
+    group.add_child(entry);
 
-    db.root.children.push(Node::Group(group));
+    db.root.add_child(group);
 
     #[cfg(feature = "save_kdbx4")]
     db.save(

--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -65,6 +65,11 @@ impl Group {
         }
     }
 
+    /// Add a child node (an entry or a group) to this group.
+    pub fn add_child(&mut self, node: impl Into<Node>) {
+        self.children.push(node.into());
+    }
+
     /// Recursively get a Group or Entry reference by specifying a path relative to the current Group
     /// ```
     /// use keepass::{Database, DatabaseKey, db::NodeRef};
@@ -184,9 +189,8 @@ impl<'a> IntoIterator for &'a Group {
 #[cfg(test)]
 mod group_tests {
     use super::Group;
-    use crate::db::{Entry, Node, NodeRef};
-    use crate::{Database, DatabaseKey};
-    use std::{fs::File, path::Path};
+    use crate::db::Entry;
+    use crate::Database;
 
     #[test]
     fn get() {
@@ -198,8 +202,8 @@ mod group_tests {
             "Title".to_string(),
             crate::db::Value::Unprotected("Sample Entry #2".to_string()),
         );
-        general_group.children.push(Node::Entry(sample_entry));
-        db.root.children.push(Node::Group(general_group));
+        general_group.add_child(sample_entry);
+        db.root.add_child(general_group);
 
         assert!(db.root.get(&["General", "Sample Entry #2"]).is_some());
         assert!(db.root.get(&["General"]).is_some());

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -341,12 +341,12 @@ mod database_tests {
     #[cfg(feature = "save_kdbx4")]
     #[test]
     fn test_save() {
-        use crate::db::{Entry, Node};
+        use crate::db::Entry;
         let mut db = Database::new(Default::default());
 
-        db.root.children.push(Node::Entry(Entry::new()));
-        db.root.children.push(Node::Entry(Entry::new()));
-        db.root.children.push(Node::Entry(Entry::new()));
+        db.root.add_child(Entry::new());
+        db.root.add_child(Entry::new());
+        db.root.add_child(Entry::new());
 
         let mut buffer = Vec::new();
 

--- a/src/db/node.rs
+++ b/src/db/node.rs
@@ -20,6 +20,18 @@ impl Node {
     }
 }
 
+impl From<Entry> for Node {
+    fn from(entry: Entry) -> Self {
+        Node::Entry(entry)
+    }
+}
+
+impl From<Group> for Node {
+    fn from(group: Group) -> Self {
+        Node::Group(group)
+    }
+}
+
 /// A shared reference to a node in the database tree structure which can either point to an Entry or a Group
 #[derive(Debug, Eq, PartialEq)]
 pub enum NodeRef<'a> {

--- a/src/format/kdb.rs
+++ b/src/format/kdb.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{CompressionConfig, DatabaseConfig, InnerCipherConfig, KdfConfig, OuterCipherConfig},
     crypt::calculate_sha256,
-    db::{Database, Entry, Group, Node, NodeRefMut, Value},
+    db::{Database, Entry, Group, NodeRefMut, Value},
     error::{DatabaseIntegrityError, DatabaseKeyError, DatabaseOpenError},
     format::DatabaseVersion,
 };
@@ -89,7 +89,7 @@ fn collapse_tail_groups(branch: &mut Vec<Group>, level: usize, root: &mut Group)
             Some(parent) => parent,
             None => root,
         };
-        parent.children.push(Node::Group(leaf));
+        parent.add_child(leaf);
     }
 }
 
@@ -261,7 +261,7 @@ fn parse_entries(
                     panic!("Follow group_path")
                 };
 
-                group.children.push(Node::Entry(entry));
+                group.add_child(entry);
                 entry = Default::default();
                 gid = None;
                 num_entries += 1;

--- a/src/format/kdbx4/mod.rs
+++ b/src/format/kdbx4/mod.rs
@@ -59,7 +59,7 @@ mod kdbx4_tests {
         config::{
             CompressionConfig, DatabaseConfig, InnerCipherConfig, KdfConfig, OuterCipherConfig,
         },
-        db::{Database, Entry, Group, HeaderAttachment, Node, Value},
+        db::{Database, Entry, Group, HeaderAttachment, Value},
         format::{kdbx4::dump::dump_kdbx4, KDBX4_CURRENT_MINOR_VERSION},
         key::DatabaseKey,
     };
@@ -68,9 +68,9 @@ mod kdbx4_tests {
         let mut db = Database::new(config);
 
         let mut root_group = Group::new("Root");
-        root_group.children.push(Node::Entry(Entry::new()));
-        root_group.children.push(Node::Entry(Entry::new()));
-        root_group.children.push(Node::Entry(Entry::new()));
+        root_group.add_child(Entry::new());
+        root_group.add_child(Entry::new());
+        root_group.add_child(Entry::new());
         db.root = root_group;
 
         let mut password_bytes: Vec<u8> = vec![];
@@ -150,7 +150,7 @@ mod kdbx4_tests {
     #[test]
     pub fn header_attachments() {
         let mut root_group = Group::new("Root");
-        root_group.children.push(Node::Entry(Entry::new()));
+        root_group.add_child(Entry::new());
 
         let mut db = Database::new(DatabaseConfig::default());
 
@@ -171,7 +171,7 @@ mod kdbx4_tests {
             Value::Unprotected("Demo entry".to_string()),
         );
 
-        db.root.children.push(Node::Entry(entry));
+        db.root.add_child(entry);
 
         let key_elements = DatabaseKey::new()
             .with_password("test")

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -105,7 +105,7 @@ mod tests {
 
         entry.history = Some(history);
 
-        root_group.children.push(Node::Entry(entry.clone()));
+        root_group.add_child(entry.clone());
 
         let mut db = Database::new(DatabaseConfig::default());
         db.root = root_group;
@@ -135,7 +135,7 @@ mod tests {
             .fields
             .insert("Title".to_string(), Value::Unprotected("ASDF".to_string()));
 
-        root_group.children.push(Node::Entry(entry));
+        root_group.add_child(entry);
 
         let mut subgroup = Group::new("Child group");
         subgroup.notes = Some("I am a subgroup".to_string());
@@ -164,7 +164,7 @@ mod tests {
             },
         );
 
-        root_group.children.push(Node::Group(subgroup));
+        root_group.add_child(subgroup);
 
         let mut db = Database::new(DatabaseConfig::default());
         db.root = root_group.clone();

--- a/src/xml_db/parse/group.rs
+++ b/src/xml_db/parse/group.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 
 use crate::{
-    db::{CustomData, Entry, Group, Node, Times},
+    db::{CustomData, Entry, Group, Times},
     xml_db::parse::{FromXml, SimpleTag, SimpleXmlEvent, XmlParseError},
 };
 
@@ -70,11 +70,11 @@ impl FromXml for Group {
                     }
                     "Entry" => {
                         let entry = Entry::from_xml(iterator, inner_cipher)?;
-                        out.children.push(Node::Entry(entry));
+                        out.add_child(entry);
                     }
                     "Group" => {
                         let group = Group::from_xml(iterator, inner_cipher)?;
-                        out.children.push(Node::Group(group));
+                        out.add_child(group);
                     }
                     "CustomData" => {
                         out.custom_data = CustomData::from_xml(iterator, inner_cipher)?;


### PR DESCRIPTION
I also added an `add_child` function that calls `.into()` directly to reduce the verbosity of this common use-case.

This PR precedes https://github.com/sseemayer/keepass-rs/pull/155