### PR TITLE
chore: only include source files in published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ license = "MIT"
 
 readme = "README.md"
 
+include = [
+  "src/",
+  "README.md",
+  "LICENSE",
+]
+
 [features]
 utilities = ["anyhow", "clap", "rpassword", "serialization", "totp"]
 serialization = ["serde", "serde_json", "chrono/serde"]


### PR DESCRIPTION
By default, `cargo publish` will include pretty much everything from the root directory in the published crate. We only really need the source code and the top-level documentation to be included in the crate.