### PR TITLE
ci: automate the releases

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -35,3 +35,74 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
+
+  get-next-version:
+    name: Get the next version
+    runs-on: ubuntu-latest
+    outputs:
+      version : ${{ steps.semantic-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: paulhatch/semantic-version@976ff820fcdca81ffc95e385a07b7eff05ddccc3
+        id: semantic-version
+        with:
+          tag_prefix: "v"
+          major_pattern: "/^breaking change:/"
+          major_regexp_flags: "ig"
+          minor_pattern: "/^feat:/"
+          minor_regexp_flags: "ig"
+          version_format: "${major}.${minor}.${patch}"
+          bump_each_commit: false
+          search_commit_body: true
+          enable_prerelease_mode: true
+
+  release:
+    name: Publish a new release
+    needs:
+      - get-next-version
+      - test
+      - coverage
+    permissions:
+      # This permission is required in order to push the new
+      # tag to the repository.
+      contents: write
+    runs-on: ubuntu-latest
+    env:
+      next-version: ${{ needs.get-next-version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Print the next version
+        run: |
+          echo "The next version is ${{ env.next-version }}"
+
+      - name: Patch the Cargo version
+        run: |
+          sed -i 's/0.0.0-placeholder-version/${{ env.next-version }}/' Cargo.toml
+          git diff
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Publish new Cargo version
+        env:
+          # This token needs to be created with the publish-update scope.
+          # The other scopes are not necessary.
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --allow-dirty
+
+      - name: Tag the next version
+        run: |
+          new_tag_name="v${{ env.next-version }}"
+          git tag "$new_tag_name" "${{ github.sha }}"
+          git push origin "$new_tag_name"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/sseemayer/keepass-rs"
 repository = "https://github.com/sseemayer/keepass-rs"
 documentation = "https://docs.rs/keepass"
 
-version = "0.6.1"
+version = "0.0.0-placeholder-version"
 authors = ["Stefan Seemayer <stefan@seemayer.de>"]
 license = "MIT"
 


### PR DESCRIPTION
This PR adds two steps to the on-merge workflow that will release a new Cargo version and push a new git tag on every new `master` commit. 

The `enable_prerelease_mode` option will make sure that version `1.0.0` is not published until we consider that the library's API is stable.

@sseemayer it looks like you were already pushing tags when publishing to Cargo so we won't have anything to do on that side before merging this PR. However, you will need to populate the repo's secrets with the `CARGO_REGISTRY_TOKEN`, since I am not an owner of that crate. The token only needs the `publish-update` scope, and I suggest that you scope the token so that it can only publish the `keepass` crate.

I've tested those two steps on a library that I maintain ([aegis-vault-rs](https://github.com/louib/aegis-vault-rs)), including making sure that breaking changes won't trigger a version `1.0.0` while in prerelease mode.

Fixes #77