### PR TITLE
build: bump argon2 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ chrono = { version = "0.4.23", default-features = false, features = [
 ] }
 
 # cryptography
-rust-argon2 = "1.0"
+rust-argon2 = "2.0"
 sha2 = "0.10"
 aes = "0.8"
 block-modes = "0.9"

--- a/src/crypt/kdf.rs
+++ b/src/crypt/kdf.rs
@@ -61,7 +61,6 @@ impl Kdf for Argon2Kdf {
             lanes: self.parallelism,
             mem_cost: (self.memory / 1024) as u32,
             secret: &[],
-            thread_mode: argon2::ThreadMode::default(),
             time_cost: self.iterations as u32,
             variant: self.variant,
             version: self.version,


### PR DESCRIPTION
parallel execution was removed from the 2.0 version of rust-argon2, as seen in the releaes notes
https://github.com/sru-systems/rust-argon2/blob/master/CHANGELOG.md#200