### PR TITLE
updates chrono dependency to avoid a security warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/sseemayer/keepass-rs"
 repository = "https://github.com/sseemayer/keepass-rs"
 documentation = "https://docs.rs/keepass"
 
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Stefan Seemayer <stefan@seemayer.de>"]
 license = "MIT"
 
@@ -37,7 +37,7 @@ xml-rs = "0.8"
 base64 = "0.21"
 hex-literal = "0.4"
 secstr = "0.5"
-chrono = { version = "0.4.23", default-features = false, features = [
+chrono = { version = "0.4.30", default-features = false, features = [
     "serde",
     "clock",
     "std",


### PR DESCRIPTION
I spotted a security warning in Medic that I think this PR will fix. All keepass-rs tests pass. 