### PR TITLE
feat: implement zeroize for DatabaseKey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ cbc = "0.1"
 
 uuid = { version = "1.2", features = ["v4", "serde"] }
 getrandom = { version = "0.2", features = ["std"] }
+zeroize = { version = "1", features = ["zeroize_derive"] }
 
 # dependencies for command-line utilities
 anyhow = { version = "1", optional = true }

--- a/src/bin/kp-dump-json.rs
+++ b/src/bin/kp-dump-json.rs
@@ -27,12 +27,7 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    let password =
-        rpassword::prompt_password("Password (or blank for none): ").expect("Read password");
-
-    if !password.is_empty() {
-        key = key.with_password(&password);
-    };
+    key = key.with_password_from_prompt("Password (or blank for none): ")?;
 
     let db = Database::open(&mut source, key)?;
 

--- a/src/bin/kp-dump-xml.rs
+++ b/src/bin/kp-dump-xml.rs
@@ -31,12 +31,7 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    let password =
-        rpassword::prompt_password("Password (or blank for none): ").expect("Read password");
-
-    if !password.is_empty() {
-        key = key.with_password(&password);
-    };
+    key = key.with_password_from_prompt("Password (or blank for none): ")?;
 
     let xml = Database::get_xml(&mut source, key)?;
 

--- a/src/bin/kp-purge-history.rs
+++ b/src/bin/kp-purge-history.rs
@@ -27,12 +27,7 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    let password =
-        rpassword::prompt_password("Password (or blank for none): ").expect("Read password");
-
-    if !password.is_empty() {
-        key = key.with_password(&password);
-    };
+    key = key.with_password_from_prompt("Password (or blank for none): ")?;
 
     let mut db = Database::open(&mut source, key.clone())?;
 

--- a/src/bin/kp-rewrite.rs
+++ b/src/bin/kp-rewrite.rs
@@ -30,12 +30,7 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    let password =
-        rpassword::prompt_password("Password (or blank for none): ").expect("Read password");
-
-    if !password.is_empty() {
-        key = key.with_password(&password);
-    };
+    key = key.with_password_from_prompt("Password (or blank for none): ")?;
 
     let db = Database::open(&mut source, key.clone())?;
 

--- a/src/bin/kp-show-db.rs
+++ b/src/bin/kp-show-db.rs
@@ -27,12 +27,7 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    let password =
-        rpassword::prompt_password("Password (or blank for none): ").expect("Read password");
-
-    if !password.is_empty() {
-        key = key.with_password(&password);
-    };
+    key = key.with_password_from_prompt("Password (or blank for none): ")?;
 
     let db = Database::open(&mut source, key)?;
 

--- a/src/bin/kp-show-otp.rs
+++ b/src/bin/kp-show-otp.rs
@@ -29,12 +29,7 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    let password =
-        rpassword::prompt_password("Password (or blank for none): ").expect("Read password");
-
-    if !password.is_empty() {
-        key = key.with_password(&password);
-    };
+    key = key.with_password_from_prompt("Password (or blank for none): ")?;
 
     let db = Database::open(&mut source, key)?;
 


### PR DESCRIPTION
I also added a utility function to make sure that the password never leaves the DatabaseKey when using a password prompt. We might consider exposing this feature from the crate at some point, but for now the `utilities` feature has to be enabled.

I think this is only a partial solution and there are probably other features from the `secrecy` crate that we might want to add in the future.

Addresses https://github.com/sseemayer/keepass-rs/issues/171