### PR TITLE
fix: handle invalid version header size

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -35,6 +35,10 @@ pub enum DatabaseVersion {
 
 impl DatabaseVersion {
     pub fn parse(data: &[u8]) -> Result<DatabaseVersion, DatabaseIntegrityError> {
+        if data.len() < DatabaseVersion::get_version_header_size() {
+            return Err(DatabaseIntegrityError::InvalidKDBXIdentifier.into());
+        }
+
         // check identifier
         if data[0..4] != KDBX_IDENTIFIER {
             return Err(DatabaseIntegrityError::InvalidKDBXIdentifier.into());


### PR DESCRIPTION
The unit tests could be a little more specific about the error type being raised, but I think testing that the function doesn't panic is good enough.

Fixes #191