### PR TITLE
fix: remove unfenced CRKey reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
+      - name: typecheck the tests
+        run: cargo check --tests
       - name: run cargo check on all feature combinations
         run: cargo hack check --feature-powerset --no-dev-deps
 

--- a/tests/file_read_tests.rs
+++ b/tests/file_read_tests.rs
@@ -2,7 +2,7 @@ mod file_read_tests {
     use keepass::{
         db::{Database, NodeRef},
         error::{DatabaseIntegrityError, DatabaseOpenError},
-        ChallengeResponseKey, DatabaseKey,
+        DatabaseKey,
     };
     use uuid::uuid;
 
@@ -400,7 +400,7 @@ mod file_read_tests {
             &mut File::open(path)?,
             DatabaseKey::new()
                 .with_password("demopass")
-                .with_challenge_response_key(ChallengeResponseKey::LocalChallenge(
+                .with_challenge_response_key(keepass::ChallengeResponseKey::LocalChallenge(
                     "0102030405060708090a0b0c0d0e0f1011121314".to_string(),
                 )),
         )?;


### PR DESCRIPTION
This reference to `ChallengeResponseKey` was not fenced behind
a feature flag, which was preventing the tests from compiling.

I also added a CI check that would have caught the issue before merging (you can see that the CI job failed for the first commit). I'm not sure why it wasn't caught by `cargo hack` though. Ideally we would try building the crate with all feature combinations, including the tests. I'm not sure this is a viable long-term solution however since the number of features will probably continue growing.