### PR TITLE
refactor: re-use header_data variable

### DIFF
--- a/src/format/kdbx4/parse.rs
+++ b/src/format/kdbx4/parse.rs
@@ -79,7 +79,7 @@ pub(crate) fn decrypt_kdbx4(
     let hmac_block_stream = &data[(inner_header_start + 64)..];
 
     // verify header
-    if header_sha256 != crypt::calculate_sha256(&[&data[0..inner_header_start]])?.as_slice() {
+    if header_sha256 != crypt::calculate_sha256(&[header_data])?.as_slice() {
         return Err(DatabaseIntegrityError::HeaderHashMismatch.into());
     }
 


### PR DESCRIPTION
The header_data variable is already defined in this function to validate the HMAC, and re-using it makes it easier to read the header checksum verification.