### PR TITLE
feat: add yubikey challenge-response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ utilities = ["anyhow", "clap", "rpassword", "serialization", "totp"]
 serialization = ["serde", "serde_json", "chrono/serde"]
 totp = ["totp-lite", "url", "base32"]
 save_kdbx4 = []
-challenge_response = ["sha1", "hex"]
+challenge_response = ["sha1", "hex", "dep:challenge_response"]
 
 default = []
 
@@ -56,6 +56,8 @@ chacha20 = "0.9"
 cipher = { version = "0.4", features = ["std"] }
 twofish = "0.7"
 cbc = "0.1"
+
+challenge_response = { version = "0.1", optional = true }
 
 uuid = { version = "1.2", features = ["v4", "serde"] }
 hex = { version = "0.4", optional = true }
@@ -113,3 +115,15 @@ required-features = ["utilities"]
 # parse and write a KeePass database (to check if all fields are kept)
 name = "kp-rewrite"
 required-features = ["utilities", "save_kdbx4"]
+
+[[bin]]
+name = "kp-yk-add"
+required-features = ["utilities", "save_kdbx4", "challenge_response"]
+
+[[bin]]
+name = "kp-yk-remove"
+required-features = ["utilities", "save_kdbx4", "challenge_response"]
+
+[[bin]]
+name = "kp-yk-recover"
+required-features = ["utilities", "save_kdbx4", "challenge_response"]

--- a/src/bin/kp-yk-add.rs
+++ b/src/bin/kp-yk-add.rs
@@ -1,0 +1,55 @@
+/// utility to add a Yubikey to a database's key
+use std::fs::File;
+
+use anyhow::Result;
+use clap::Parser;
+
+use keepass::{ChallengeResponseKey, Database, DatabaseKey};
+
+#[derive(Parser, Debug)]
+#[command(version, about)]
+struct Args {
+    /// Provide a .kdbx database
+    in_kdbx: String,
+
+    /// Output file to write
+    out_kdbx: String,
+
+    /// The slot number of the yubikey to add to the Database
+    slot: String,
+
+    /// The serial number of the yubikey to add to the Database
+    #[arg(short = 'n', long)]
+    serial_number: Option<u32>,
+
+    /// Provide a keyfile
+    #[arg(short = 'k', long)]
+    keyfile: Option<String>,
+}
+
+pub fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let mut source = File::open(args.in_kdbx)?;
+    let mut key = DatabaseKey::new();
+
+    if let Some(f) = args.keyfile {
+        key = key.with_keyfile(&mut File::open(f)?)?;
+    }
+
+    key = key.with_password_from_prompt("Password (or blank for none): ")?;
+
+    let db = Database::open(&mut source, key.clone())?;
+
+    let yubikey = ChallengeResponseKey::get_yubikey(args.serial_number)?;
+
+    let new_key = key.with_challenge_response_key(ChallengeResponseKey::YubikeyChallenge(yubikey, args.slot));
+
+    let mut out_file = File::create(args.out_kdbx)?;
+
+    db.save(&mut out_file, new_key)?;
+
+    println!("Yubikey was added to the database key.");
+
+    Ok(())
+}

--- a/src/bin/kp-yk-recover.rs
+++ b/src/bin/kp-yk-recover.rs
@@ -1,0 +1,48 @@
+/// utility to recover a Yubikey-protected database using the HMAC-SHA1 secret
+use std::fs::File;
+
+use anyhow::Result;
+use clap::Parser;
+
+use keepass::{Database, DatabaseKey};
+
+#[derive(Parser, Debug)]
+#[command(version, about)]
+struct Args {
+    /// Provide a .kdbx database
+    in_kdbx: String,
+
+    /// Output file to write
+    out_kdbx: String,
+
+    /// Provide a keyfile
+    #[arg(short = 'k', long)]
+    keyfile: Option<String>,
+}
+
+pub fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let mut source = File::open(args.in_kdbx)?;
+    let mut key = DatabaseKey::new();
+
+    if let Some(f) = args.keyfile {
+        key = key.with_keyfile(&mut File::open(f)?)?;
+    }
+
+    key = key.with_password_from_prompt("Password (or blank for none): ")?;
+
+    let key_without_yubikey = key.clone();
+
+    key = key.with_hmac_sha1_secret_from_prompt("HMAC-SHA1 secret: ")?;
+
+    let db = Database::open(&mut source, key.clone())?;
+
+    let mut out_file = File::create(args.out_kdbx)?;
+
+    db.save(&mut out_file, key_without_yubikey)?;
+
+    println!("Yubikey was removed from the database key.");
+
+    Ok(())
+}

--- a/src/bin/kp-yk-remove.rs
+++ b/src/bin/kp-yk-remove.rs
@@ -1,0 +1,57 @@
+/// utility to remove a Yubikey from a database's key
+use std::fs::File;
+
+use anyhow::Result;
+use clap::Parser;
+
+use keepass::{ChallengeResponseKey, Database, DatabaseKey};
+
+#[derive(Parser, Debug)]
+#[command(version, about)]
+struct Args {
+    /// Provide a .kdbx database
+    in_kdbx: String,
+
+    /// Output file to write
+    out_kdbx: String,
+
+    /// The slot number of the yubikey to remove from the Database
+    slot: String,
+
+    /// The serial number of the yubikey to remove from the Database
+    #[arg(short = 'n', long)]
+    serial_number: Option<u32>,
+
+    /// Provide a keyfile
+    #[arg(short = 'k', long)]
+    keyfile: Option<String>,
+}
+
+pub fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let mut source = File::open(args.in_kdbx)?;
+    let mut key = DatabaseKey::new();
+
+    if let Some(f) = args.keyfile {
+        key = key.with_keyfile(&mut File::open(f)?)?;
+    }
+
+    key = key.with_password_from_prompt("Password (or blank for none): ")?;
+
+    let key_without_yubikey = key.clone();
+
+    let yubikey = ChallengeResponseKey::get_yubikey(args.serial_number)?;
+
+    key = key.with_challenge_response_key(ChallengeResponseKey::YubikeyChallenge(yubikey, args.slot));
+
+    let db = Database::open(&mut source, key.clone())?;
+
+    let mut out_file = File::create(args.out_kdbx)?;
+
+    db.save(&mut out_file, key_without_yubikey)?;
+
+    println!("Yubikey was removed from the database key.");
+
+    Ok(())
+}

--- a/tests/file_read_tests.rs
+++ b/tests/file_read_tests.rs
@@ -408,6 +408,27 @@ mod file_read_tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "challenge_response")]
+    fn open_kdbx4_with_yubikey_challenge_response_key() -> Result<(), DatabaseOpenError> {
+        let path = Path::new("tests/resources/test_db_with_challenge_response_key.kdbx");
+        let yubikey = keepass::ChallengeResponseKey::get_yubikey(None)?;
+        let db = Database::open(
+            &mut File::open(path)?,
+            DatabaseKey::new()
+                .with_password("demopass")
+                .with_challenge_response_key(keepass::ChallengeResponseKey::YubikeyChallenge(
+                    yubikey,
+                    "2".to_string(),
+                )),
+        )?;
+
+        assert_eq!(db.root.name, "Root");
+        assert_eq!(db.root.children.len(), 2);
+        Ok(())
+    }
+
+    #[test]
     fn test_get_version() -> Result<(), DatabaseIntegrityError> {
         let path = Path::new("tests/resources/test_db_with_password.kdbx");
         let version = Database::get_version(&mut File::open(path)?)?;


### PR DESCRIPTION
This commit adds support for YubiKey challenge-response keys, and also adds a few utilities so that we can test the new feature. I only tested on Linux, but would be interested to know if it works on Mac and Windows. I also added a utility to recover a database by using the HMAC-SHA1 secret directly. This will allow us to deprecate the [`keepassxc-cr-recovery`](https://github.com/keepassxreboot/keepassxc/tree/develop/utils/keepassxc-cr-recovery) tool from keepassxc @droidmonkey 

The new unit test is ignored since a properly-configured yubikey is required for the test to pass.

Fixes #165 