### PR TITLE
ci: migrate to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
+          components: rustfmt
       - name: run cargo doc
         run: cargo doc
 
@@ -51,11 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - name: run cargo test
         run: cargo test --all-features
 
@@ -64,29 +61,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
+
       - name: install armv7 target
         run: rustup target add armv7-unknown-linux-musleabihf
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --release --target armv7-unknown-linux-musleabihf tests::kdbx4_entry --all-features
+
+      - name: Install cross
+        run: |
+          cargo install cross
+
+      - run: |
+          cross test --release --target armv7-unknown-linux-musleabihf tests::kdbx4_entry --all-features
 
   formatting:
     name: Code Formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
+          components: rustfmt
       - name: running rustfmt
         run: |
           files=$(find . -name '*.rs')

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,11 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - name: run cargo test
         run: cargo test --all-features
 
@@ -87,11 +85,9 @@ jobs:
           sed -i 's/0.0.0-placeholder-version/${{ env.next-version }}/' Cargo.toml
           git diff
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
       - name: Publish new Cargo version
         env:


### PR DESCRIPTION
This will get rid of all the warnings, as seen [here](https://github.com/sseemayer/keepass-rs/actions/runs/7155313481?pr=198) (now) compared to [here](https://github.com/sseemayer/keepass-rs/actions/runs/7149191407?pr=197) (before)

Fixes https://github.com/sseemayer/keepass-rs/issues/161