### PR TITLE
chore: configure rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+# https://rust-lang.github.io/rustfmt for all the options.
+merge_derives = false
+max_width = 112

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,9 +85,7 @@ impl OuterCipherConfig {
         match self {
             OuterCipherConfig::AES256 => Ok(Box::new(ciphers::AES256Cipher::new(key, iv)?)),
             OuterCipherConfig::Twofish => Ok(Box::new(ciphers::TwofishCipher::new(key, iv)?)),
-            OuterCipherConfig::ChaCha20 => {
-                Ok(Box::new(ciphers::ChaCha20Cipher::new_key_iv(key, iv)?))
-            }
+            OuterCipherConfig::ChaCha20 => Ok(Box::new(ciphers::ChaCha20Cipher::new_key_iv(key, iv)?)),
         }
     }
 
@@ -133,10 +131,7 @@ pub enum InnerCipherConfig {
 }
 
 impl InnerCipherConfig {
-    pub(crate) fn get_cipher(
-        &self,
-        key: &[u8],
-    ) -> Result<Box<dyn ciphers::Cipher>, CryptographyError> {
+    pub(crate) fn get_cipher(&self, key: &[u8]) -> Result<Box<dyn ciphers::Cipher>, CryptographyError> {
         match self {
             InnerCipherConfig::Plain => Ok(Box::new(ciphers::PlainCipher::new(key)?)),
             InnerCipherConfig::Salsa20 => Ok(Box::new(ciphers::Salsa20Cipher::new(key)?)),
@@ -198,10 +193,7 @@ pub enum KdfConfig {
         memory: u64,
         parallelism: u32,
 
-        #[cfg_attr(
-            feature = "serialization",
-            serde(serialize_with = "serialize_argon2_version")
-        )]
+        #[cfg_attr(feature = "serialization", serde(serialize_with = "serialize_argon2_version"))]
         version: argon2::Version,
     },
     /// Derive keys with Argon2id
@@ -210,10 +202,7 @@ pub enum KdfConfig {
         memory: u64,
         parallelism: u32,
 
-        #[cfg_attr(
-            feature = "serialization",
-            serde(serialize_with = "serialize_argon2_version")
-        )]
+        #[cfg_attr(feature = "serialization", serde(serialize_with = "serialize_argon2_version"))]
         version: argon2::Version,
     },
 }
@@ -237,9 +226,7 @@ impl KdfConfig {
 
     /// For writing out a database, generate a new KDF seed from the config and return the KDF
     /// and the generated seed
-    pub(crate) fn get_kdf_and_seed(
-        &self,
-    ) -> Result<(Box<dyn kdf::Kdf>, Vec<u8>), getrandom::Error> {
+    pub(crate) fn get_kdf_and_seed(&self) -> Result<(Box<dyn kdf::Kdf>, Vec<u8>), getrandom::Error> {
         let mut kdf_seed = vec![0; self.seed_size()];
         getrandom::getrandom(&mut kdf_seed)?;
 

--- a/src/crypt/ciphers.rs
+++ b/src/crypt/ciphers.rs
@@ -42,8 +42,7 @@ impl Cipher for AES256Cipher {
     fn encrypt(&mut self, plaintext: &[u8]) -> Result<Vec<u8>, CryptographyError> {
         let cipher = Aes256CbcEncryptor::new_from_slices(&self.key, &self.iv)?;
 
-        let ciphertext =
-            cipher.encrypt_padded_vec_mut::<twofish::cipher::block_padding::Pkcs7>(plaintext);
+        let ciphertext = cipher.encrypt_padded_vec_mut::<twofish::cipher::block_padding::Pkcs7>(plaintext);
 
         Ok(ciphertext)
     }
@@ -90,8 +89,7 @@ impl Cipher for TwofishCipher {
     fn encrypt(&mut self, plaintext: &[u8]) -> Result<Vec<u8>, CryptographyError> {
         let cipher = TwofishCbcEncryptor::new_from_slices(&self.key, &self.iv)?;
 
-        let ciphertext =
-            cipher.encrypt_padded_vec_mut::<twofish::cipher::block_padding::Pkcs7>(plaintext);
+        let ciphertext = cipher.encrypt_padded_vec_mut::<twofish::cipher::block_padding::Pkcs7>(plaintext);
 
         Ok(ciphertext)
     }

--- a/src/crypt/mod.rs
+++ b/src/crypt/mod.rs
@@ -44,9 +44,7 @@ pub(crate) fn calculate_hmac_sha1(
     Ok(result.into_bytes())
 }
 
-pub(crate) fn calculate_sha256(
-    elements: &[&[u8]],
-) -> Result<GenericArray<u8, U32>, CryptographyError> {
+pub(crate) fn calculate_sha256(elements: &[&[u8]]) -> Result<GenericArray<u8, U32>, CryptographyError> {
     let mut digest = Sha256::new();
 
     for element in elements {
@@ -56,9 +54,7 @@ pub(crate) fn calculate_sha256(
     Ok(digest.finalize())
 }
 
-pub(crate) fn calculate_sha512(
-    elements: &[&[u8]],
-) -> Result<GenericArray<u8, U64>, CryptographyError> {
+pub(crate) fn calculate_sha512(elements: &[&[u8]]) -> Result<GenericArray<u8, U64>, CryptographyError> {
     let mut digest = Sha512::new();
 
     for element in elements {

--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -195,9 +195,7 @@ impl serde::Serialize for Value {
         match self {
             Value::Bytes(b) => serializer.serialize_bytes(b),
             Value::Unprotected(u) => serializer.serialize_str(u),
-            Value::Protected(p) => {
-                serializer.serialize_str(String::from_utf8_lossy(p.unsecure()).as_ref())
-            }
+            Value::Protected(p) => serializer.serialize_str(String::from_utf8_lossy(p.unsecure()).as_ref()),
         }
     }
 }
@@ -279,10 +277,9 @@ mod entry_tests {
         let mut entry = Entry::new();
         let mut last_modification_time = entry.times.get_last_modification().unwrap().clone();
 
-        entry.fields.insert(
-            "Username".to_string(),
-            Value::Unprotected("user".to_string()),
-        );
+        entry
+            .fields
+            .insert("Username".to_string(), Value::Unprotected("user".to_string()));
         // Making sure to wait 1 sec before update the history, to make
         // sure that we get a different modification timestamp.
         thread::sleep(time::Duration::from_secs(1));
@@ -307,10 +304,9 @@ mod entry_tests {
             &last_modification_time
         );
 
-        entry.fields.insert(
-            "Title".to_string(),
-            Value::Unprotected("first title".to_string()),
-        );
+        entry
+            .fields
+            .insert("Title".to_string(), Value::Unprotected("first title".to_string()));
 
         assert!(entry.update_history());
         assert!(entry.history.is_some());
@@ -384,8 +380,7 @@ mod entry_tests {
         );
 
         assert_eq!(
-            serde_json::to_string(&Value::Protected(SecStr::new("ABC".as_bytes().to_vec())))
-                .unwrap(),
+            serde_json::to_string(&Value::Protected(SecStr::new("ABC".as_bytes().to_vec()))).unwrap(),
             "\"ABC\"".to_string()
         );
     }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -57,10 +57,7 @@ pub struct Database {
 
 impl Database {
     /// Parse a database from a std::io::Read
-    pub fn open(
-        source: &mut dyn std::io::Read,
-        key: DatabaseKey,
-    ) -> Result<Database, DatabaseOpenError> {
+    pub fn open(source: &mut dyn std::io::Read, key: DatabaseKey) -> Result<Database, DatabaseOpenError> {
         let mut data = Vec::new();
         source.read_to_end(&mut data)?;
 
@@ -97,10 +94,7 @@ impl Database {
     }
 
     /// Helper function to load a database into its internal XML chunks
-    pub fn get_xml(
-        source: &mut dyn std::io::Read,
-        key: DatabaseKey,
-    ) -> Result<Vec<u8>, DatabaseOpenError> {
+    pub fn get_xml(source: &mut dyn std::io::Read, key: DatabaseKey) -> Result<Vec<u8>, DatabaseOpenError> {
         let mut data = Vec::new();
         source.read_to_end(&mut data)?;
 
@@ -117,9 +111,7 @@ impl Database {
     }
 
     /// Get the version of a database without decrypting it
-    pub fn get_version(
-        source: &mut dyn std::io::Read,
-    ) -> Result<DatabaseVersion, DatabaseIntegrityError> {
+    pub fn get_version(source: &mut dyn std::io::Read) -> Result<DatabaseVersion, DatabaseIntegrityError> {
         let mut data = Vec::new();
         data.resize(DatabaseVersion::get_version_header_size(), 0);
         source.read(&mut data)?;
@@ -196,8 +188,7 @@ impl Times {
     }
 
     pub fn set_last_access(&mut self, time: NaiveDateTime) {
-        self.times
-            .insert(LAST_ACCESS_TIME_TAG_NAME.to_string(), time);
+        self.times.insert(LAST_ACCESS_TIME_TAG_NAME.to_string(), time);
     }
 
     pub fn get_location_changed(&self) -> Option<&NaiveDateTime> {
@@ -205,8 +196,7 @@ impl Times {
     }
 
     pub fn set_location_changed(&mut self, time: NaiveDateTime) {
-        self.times
-            .insert(LOCATION_CHANGED_TAG_NAME.to_string(), time);
+        self.times.insert(LOCATION_CHANGED_TAG_NAME.to_string(), time);
     }
 
     // Returns the current time, without the nanoseconds since
@@ -301,8 +291,8 @@ impl FromStr for Color {
             return Err(ParseColorError(s.to_string()));
         }
 
-        let v = u64::from_str_radix(s.trim_start_matches('#'), 16)
-            .map_err(|_e| ParseColorError(s.to_string()))?;
+        let v =
+            u64::from_str_radix(s.trim_start_matches('#'), 16).map_err(|_e| ParseColorError(s.to_string()))?;
 
         let r = ((v >> 16) & 0xff) as u8;
         let g = ((v >> 8) & 0xff) as u8;

--- a/src/db/otp.rs
+++ b/src/db/otp.rs
@@ -119,8 +119,8 @@ impl std::str::FromStr for TOTP {
         let secret = secret.ok_or(TOTPError::MissingField("secret"))?;
         let issuer = issuer.ok_or(TOTPError::MissingField("issuer"))?;
 
-        let secret = base32::decode(base32::Alphabet::RFC4648 { padding: true }, &secret)
-            .ok_or(TOTPError::Base32)?;
+        let secret =
+            base32::decode(base32::Alphabet::RFC4648 { padding: true }, &secret).ok_or(TOTPError::Base32)?;
 
         Ok(TOTP {
             label,
@@ -137,15 +137,9 @@ impl TOTP {
     /// Get the one-time code for a specific unix timestamp
     pub fn value_at(&self, time: u64) -> OTPCode {
         let code = match self.algorithm {
-            TOTPAlgorithm::Sha1 => {
-                totp_custom::<Sha1>(self.period, self.digits, &self.secret, time)
-            }
-            TOTPAlgorithm::Sha256 => {
-                totp_custom::<Sha256>(self.period, self.digits, &self.secret, time)
-            }
-            TOTPAlgorithm::Sha512 => {
-                totp_custom::<Sha512>(self.period, self.digits, &self.secret, time)
-            }
+            TOTPAlgorithm::Sha1 => totp_custom::<Sha1>(self.period, self.digits, &self.secret, time),
+            TOTPAlgorithm::Sha256 => totp_custom::<Sha256>(self.period, self.digits, &self.secret, time),
+            TOTPAlgorithm::Sha512 => totp_custom::<Sha512>(self.period, self.digits, &self.secret, time),
         };
 
         let valid_for = Duration::from_secs(self.period - (time % self.period));
@@ -177,12 +171,10 @@ mod kdbx4_otp_tests {
     fn kdbx4_entry() -> Result<(), Box<dyn std::error::Error>> {
         // KDBX4 database format Base64 encodes ExpiryTime (and all other XML timestamps)
         let path = Path::new("tests/resources/test_db_kdbx4_with_totp_entry.kdbx");
-        let db = Database::open(
-            &mut File::open(path)?,
-            DatabaseKey::new().with_password("test"),
-        )?;
+        let db = Database::open(&mut File::open(path)?, DatabaseKey::new().with_password("test"))?;
 
-        let otp_str = "otpauth://totp/KeePassXC:none?secret=JBSWY3DPEHPK3PXP&period=30&digits=6&issuer=KeePassXC";
+        let otp_str =
+            "otpauth://totp/KeePassXC:none?secret=JBSWY3DPEHPK3PXP&period=30&digits=6&issuer=KeePassXC";
 
         // get an entry on the root node
         if let Some(NodeRef::Entry(e)) = db.root.get(&["this entry has totp"]) {
@@ -197,7 +189,8 @@ mod kdbx4_otp_tests {
 
     #[test]
     fn totp_default() -> Result<(), TOTPError> {
-        let otp_str = "otpauth://totp/KeePassXC:none?secret=JBSWY3DPEHPK3PXP&period=30&digits=6&issuer=KeePassXC";
+        let otp_str =
+            "otpauth://totp/KeePassXC:none?secret=JBSWY3DPEHPK3PXP&period=30&digits=6&issuer=KeePassXC";
 
         let expected = TOTP {
             label: "KeePassXC:none".to_string(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,15 +64,8 @@ pub enum DatabaseIntegrityError {
     #[error("Missing group level")]
     MissingKDBGroupLevel,
 
-    #[error(
-        "Invalid group level {} (current level {})",
-        group_level,
-        current_level
-    )]
-    InvalidKDBGroupLevel {
-        group_level: u16,
-        current_level: u16,
-    },
+    #[error("Invalid group level {} (current level {})", group_level, current_level)]
+    InvalidKDBGroupLevel { group_level: u16, current_level: u16 },
 
     #[error("Missing group ID")]
     MissingKDBGroupId,

--- a/src/format/kdb.rs
+++ b/src/format/kdb.rs
@@ -47,9 +47,7 @@ fn parse_header(data: &[u8]) -> Result<KDBHeader, DatabaseIntegrityError> {
 }
 
 fn from_utf8(data: &[u8]) -> String {
-    String::from_utf8_lossy(data)
-        .trim_end_matches('\0')
-        .to_owned()
+    String::from_utf8_lossy(data).trim_end_matches('\0').to_owned()
 }
 
 fn ensure_length(
@@ -144,8 +142,7 @@ fn parse_groups(
             0xffff => {
                 ensure_length(field_type, field_size, 0)?;
 
-                let level =
-                    level.ok_or_else(|| DatabaseIntegrityError::MissingKDBGroupLevel)? as usize;
+                let level = level.ok_or_else(|| DatabaseIntegrityError::MissingKDBGroupLevel)? as usize;
 
                 // Update the current group tree branch (collapse previous sub-branch, initiate
                 // current sub-branch)
@@ -239,10 +236,9 @@ fn parse_entries(
             }
             0x000e => {
                 // BinaryData
-                entry.fields.insert(
-                    String::from("BinaryData"),
-                    Value::Bytes(field_value.to_vec()),
-                );
+                entry
+                    .fields
+                    .insert(String::from("BinaryData"), Value::Bytes(field_value.to_vec()));
             }
             0xffff => {
                 ensure_length(field_type, field_size, 0)?;

--- a/src/format/kdbx3.rs
+++ b/src/format/kdbx3.rs
@@ -73,8 +73,7 @@ fn parse_outer_header(data: &[u8]) -> Result<KDBX3Header, DatabaseOpenError> {
             //            should be used to encrypt the payload
             2 => {
                 outer_cipher = Some(
-                    OuterCipherConfig::try_from(entry_buffer)
-                        .map_err(|e| DatabaseIntegrityError::from(e))?,
+                    OuterCipherConfig::try_from(entry_buffer).map_err(|e| DatabaseIntegrityError::from(e))?,
                 );
             }
 
@@ -161,10 +160,7 @@ fn parse_outer_header(data: &[u8]) -> Result<KDBX3Header, DatabaseOpenError> {
 }
 
 /// Open, decrypt and parse a KeePass database from a source and a password
-pub(crate) fn parse_kdbx3(
-    data: &[u8],
-    db_key: &DatabaseKey,
-) -> Result<Database, DatabaseOpenError> {
+pub(crate) fn parse_kdbx3(data: &[u8], db_key: &DatabaseKey) -> Result<Database, DatabaseOpenError> {
     let (config, mut inner_decryptor, xml) = decrypt_kdbx3(data, db_key)?;
 
     // Parse XML data blocks

--- a/src/format/kdbx4/dump.rs
+++ b/src/format/kdbx4/dump.rs
@@ -8,10 +8,10 @@ use crate::{
     error::DatabaseSaveError,
     format::{
         kdbx4::{
-            KDBX4InnerHeader, KDBX4OuterHeader, HEADER_COMPRESSION_ID, HEADER_ENCRYPTION_IV,
-            HEADER_END, HEADER_KDF_PARAMS, HEADER_MASTER_SEED, HEADER_MASTER_SEED_SIZE,
-            HEADER_OUTER_ENCRYPTION_ID, INNER_HEADER_BINARY_ATTACHMENTS, INNER_HEADER_END,
-            INNER_HEADER_RANDOM_STREAM_ID, INNER_HEADER_RANDOM_STREAM_KEY,
+            KDBX4InnerHeader, KDBX4OuterHeader, HEADER_COMPRESSION_ID, HEADER_ENCRYPTION_IV, HEADER_END,
+            HEADER_KDF_PARAMS, HEADER_MASTER_SEED, HEADER_MASTER_SEED_SIZE, HEADER_OUTER_ENCRYPTION_ID,
+            INNER_HEADER_BINARY_ATTACHMENTS, INNER_HEADER_END, INNER_HEADER_RANDOM_STREAM_ID,
+            INNER_HEADER_RANDOM_STREAM_KEY,
         },
         DatabaseVersion,
     },
@@ -73,11 +73,8 @@ pub fn dump_kdbx4(
     let master_key = crypt::calculate_sha256(&[&master_seed, &transformed_key])?;
 
     // verify credentials
-    let hmac_key = crypt::calculate_sha512(&[
-        &master_seed,
-        &transformed_key,
-        &hmac_block_stream::HMAC_KEY_END,
-    ])?;
+    let hmac_key =
+        crypt::calculate_sha512(&[&master_seed, &transformed_key, &hmac_block_stream::HMAC_KEY_END])?;
     let header_hmac_key = hmac_block_stream::get_hmac_block_key(u64::max_value(), &hmac_key)?;
     let header_hmac = crypt::calculate_hmac(&[&header_data], &header_hmac_key)?;
 

--- a/src/format/kdbx4/mod.rs
+++ b/src/format/kdbx4/mod.rs
@@ -56,9 +56,7 @@ mod kdbx4_tests {
     use super::*;
 
     use crate::{
-        config::{
-            CompressionConfig, DatabaseConfig, InnerCipherConfig, KdfConfig, OuterCipherConfig,
-        },
+        config::{CompressionConfig, DatabaseConfig, InnerCipherConfig, KdfConfig, OuterCipherConfig},
         db::{Database, Entry, Group, HeaderAttachment, Value},
         format::{kdbx4::dump::dump_kdbx4, KDBX4_CURRENT_MINOR_VERSION},
         key::DatabaseKey,
@@ -196,10 +194,9 @@ mod kdbx4_tests {
         ];
 
         let mut entry = Entry::new();
-        entry.fields.insert(
-            "Title".to_string(),
-            Value::Unprotected("Demo entry".to_string()),
-        );
+        entry
+            .fields
+            .insert("Title".to_string(), Value::Unprotected("Demo entry".to_string()));
 
         db.root.add_child(entry);
 

--- a/src/hmac_block_stream.rs
+++ b/src/hmac_block_stream.rs
@@ -32,11 +32,8 @@ pub(crate) fn read_hmac_block_stream(
         LittleEndian::write_u64(&mut block_index_buf, block_index as u64);
 
         if hmac
-            != crate::crypt::calculate_hmac(
-                &[&block_index_buf, size_bytes, &block],
-                &hmac_block_key,
-            )?
-            .as_slice()
+            != crate::crypt::calculate_hmac(&[&block_index_buf, size_bytes, &block], &hmac_block_key)?
+                .as_slice()
         {
             return Err(BlockStreamError::BlockHashMismatch { block_index }.into());
         }
@@ -78,10 +75,7 @@ pub(crate) fn write_hmac_block_stream(
         let mut block_index_buf = [0u8; 8];
         LittleEndian::write_u64(&mut block_index_buf, block_index as u64);
 
-        let hmac = crate::crypt::calculate_hmac(
-            &[&block_index_buf, &size_bytes, &block],
-            &hmac_block_key,
-        )?;
+        let hmac = crate::crypt::calculate_hmac(&[&block_index_buf, &size_bytes, &block], &hmac_block_key)?;
 
         pos += 36 + size;
         block_index += 1;
@@ -97,8 +91,7 @@ pub(crate) fn write_hmac_block_stream(
     LittleEndian::write_u64(&mut block_index_buf, block_index as u64);
 
     let size_bytes = vec![0; 4];
-    let hmac =
-        crate::crypt::calculate_hmac(&[&block_index_buf, &size_bytes, &[]], &hmac_block_key)?;
+    let hmac = crate::crypt::calculate_hmac(&[&block_index_buf, &size_bytes, &[]], &hmac_block_key)?;
 
     out.extend_from_slice(&hmac);
     out.extend_from_slice(&size_bytes);

--- a/src/key.rs
+++ b/src/key.rs
@@ -74,8 +74,7 @@ impl ChallengeResponseKey {
                     return DatabaseKeyError::ChallengeResponseKeyError(e.to_string());
                 })?;
 
-                let response =
-                    crate::crypt::calculate_hmac_sha1(&[&challenge], &secret_bytes)?.to_vec();
+                let response = crate::crypt::calculate_hmac_sha1(&[&challenge], &secret_bytes)?.to_vec();
                 Ok(response)
             }
         }
@@ -100,10 +99,7 @@ impl DatabaseKey {
     }
 
     #[cfg(feature = "utilities")]
-    pub fn with_password_from_prompt(
-        mut self,
-        prompt_message: &str,
-    ) -> Result<Self, std::io::Error> {
+    pub fn with_password_from_prompt(mut self, prompt_message: &str) -> Result<Self, std::io::Error> {
         self.password = Some(rpassword::prompt_password(prompt_message)?);
         // FIXME This prevents using an empty password when using the password prompt.
         if self.password == Some("".to_string()) {
@@ -122,10 +118,7 @@ impl DatabaseKey {
     }
 
     #[cfg(feature = "challenge_response")]
-    pub fn with_challenge_response_key(
-        mut self,
-        challenge_response_key: ChallengeResponseKey,
-    ) -> Self {
+    pub fn with_challenge_response_key(mut self, challenge_response_key: ChallengeResponseKey) -> Self {
         self.challenge_response_key = Some(challenge_response_key);
         self
     }
@@ -181,9 +174,7 @@ mod key_tests {
 
     #[test]
     fn test_key() -> Result<(), DatabaseKeyError> {
-        let ke = DatabaseKey::new()
-            .with_password("asdf")
-            .get_key_elements()?;
+        let ke = DatabaseKey::new().with_password("asdf").get_key_elements()?;
         assert_eq!(ke.len(), 1);
 
         let ke = DatabaseKey::new()
@@ -204,16 +195,17 @@ mod key_tests {
 
         let ke = DatabaseKey::new()
             .with_keyfile(
-                &mut "<KeyFile><Key><Data>0!23456789ABCDEF0123456789ABCDEF</Data></Key></KeyFile>"
-                    .as_bytes(),
+                &mut "<KeyFile><Key><Data>0!23456789ABCDEF0123456789ABCDEF</Data></Key></KeyFile>".as_bytes(),
             )?
             .get_key_elements()?;
         assert_eq!(ke.len(), 1);
 
-        let ke = DatabaseKey::new().with_keyfile(
-            &mut "<KeyFile><Key><Data>NXyYiJMHg3ls+eBmjbAjWec9lcOToJiofbhNiFMTJMw=</Data></Key></KeyFile>".as_bytes(),
-        )?
-        .get_key_elements()?;
+        let ke = DatabaseKey::new()
+            .with_keyfile(
+                &mut "<KeyFile><Key><Data>NXyYiJMHg3ls+eBmjbAjWec9lcOToJiofbhNiFMTJMw=</Data></Key></KeyFile>"
+                    .as_bytes(),
+            )?
+            .get_key_elements()?;
         assert_eq!(ke.len(), 1);
 
         // other XML files will just be hashed as a "bare" keyfile

--- a/src/variant_dictionary.rs
+++ b/src/variant_dictionary.rs
@@ -21,9 +21,7 @@ pub(crate) struct VariantDictionary {
 
 impl VariantDictionary {
     pub(crate) fn new() -> Self {
-        Self {
-            data: HashMap::new(),
-        }
+        Self { data: HashMap::new() }
     }
 
     pub(crate) fn parse(buffer: &[u8]) -> Result<VariantDictionary, VariantDictionaryError> {
@@ -58,9 +56,9 @@ impl VariantDictionary {
                 BOOL_TYPE_ID => VariantDictionaryValue::Bool(value_buffer != [0]),
                 I32_TYPE_ID => VariantDictionaryValue::Int32(LittleEndian::read_i32(value_buffer)),
                 I64_TYPE_ID => VariantDictionaryValue::Int64(LittleEndian::read_i64(value_buffer)),
-                STR_TYPE_ID => VariantDictionaryValue::String(
-                    String::from_utf8_lossy(value_buffer).to_string(),
-                ),
+                STR_TYPE_ID => {
+                    VariantDictionaryValue::String(String::from_utf8_lossy(value_buffer).to_string())
+                }
                 BYTES_TYPE_ID => VariantDictionaryValue::ByteArray(value_buffer.to_vec()),
                 _ => {
                     return Err(VariantDictionaryError::InvalidValueType { value_type });
@@ -140,13 +138,10 @@ impl VariantDictionary {
         let vdv = self
             .data
             .get(key)
-            .ok_or_else(|| VariantDictionaryError::MissingKey {
-                key: key.to_owned(),
-            })?;
+            .ok_or_else(|| VariantDictionaryError::MissingKey { key: key.to_owned() })?;
 
-        vdv.into().ok_or_else(|| VariantDictionaryError::Mistyped {
-            key: key.to_owned(),
-        })
+        vdv.into()
+            .ok_or_else(|| VariantDictionaryError::Mistyped { key: key.to_owned() })
     }
 
     pub(crate) fn set<T>(&mut self, key: &str, value: T)
@@ -282,10 +277,7 @@ mod variant_dictionary_tests {
     #[test]
     fn parsing_errors() -> Result<(), VariantDictionaryError> {
         let res = VariantDictionary::parse("not-a-variant-dictionary".as_bytes());
-        assert!(matches!(
-            res,
-            Err(VariantDictionaryError::InvalidVersion { .. })
-        ));
+        assert!(matches!(res, Err(VariantDictionaryError::InvalidVersion { .. })));
 
         let res = VariantDictionary::parse(&hex!("0001"));
         assert!(matches!(res, Err(VariantDictionaryError::NotTerminated)));

--- a/src/xml_db/dump/entry.rs
+++ b/src/xml_db/dump/entry.rs
@@ -77,8 +77,9 @@ impl DumpXml for Value {
         inner_cipher: &mut dyn Cipher,
     ) -> Result<(), xml::writer::Error> {
         match self {
-            Value::Bytes(b) => SimpleTag("Value", std::str::from_utf8(b).expect("utf-8"))
-                .dump_xml(writer, inner_cipher),
+            Value::Bytes(b) => {
+                SimpleTag("Value", std::str::from_utf8(b).expect("utf-8")).dump_xml(writer, inner_cipher)
+            }
             Value::Unprotected(s) => SimpleTag("Value", s).dump_xml(writer, inner_cipher),
             Value::Protected(p) => {
                 writer.write(WriterEvent::start_element("Value").attr("Protected", "True"))?;

--- a/src/xml_db/dump/mod.rs
+++ b/src/xml_db/dump/mod.rs
@@ -29,9 +29,7 @@ pub(crate) fn dump(
     inner_cipher: &mut dyn Cipher,
     writer: &mut dyn Write,
 ) -> Result<(), xml::writer::Error> {
-    let mut xml_writer = EmitterConfig::new()
-        .perform_indent(false)
-        .create_writer(writer);
+    let mut xml_writer = EmitterConfig::new().perform_indent(false).create_writer(writer);
 
     db.dump_xml(&mut xml_writer, inner_cipher)?;
 
@@ -66,11 +64,7 @@ impl DumpXml for bool {
         writer: &mut EventWriter<E>,
         _inner_cipher: &mut dyn Cipher,
     ) -> Result<(), xml::writer::Error> {
-        writer.write(WriterEvent::characters(if *self {
-            "True"
-        } else {
-            "False"
-        }))
+        writer.write(WriterEvent::characters(if *self { "True" } else { "False" }))
     }
 }
 

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -46,10 +46,9 @@ mod tests {
         entry
             .fields
             .insert("Title".to_string(), Value::Unprotected("ASDF".to_string()));
-        entry.fields.insert(
-            "UserName".to_string(),
-            Value::Unprotected("ghj".to_string()),
-        );
+        entry
+            .fields
+            .insert("UserName".to_string(), Value::Unprotected("ghj".to_string()));
         entry.fields.insert(
             "Password".to_string(),
             Value::Protected(std::str::from_utf8(b"klmno").unwrap().into()),
@@ -262,9 +261,7 @@ mod tests {
                     (
                         "custom-data-protected-key".to_string(),
                         CustomDataItem {
-                            value: Some(Value::Protected(SecStr::new(
-                                b"custom-data-value".to_vec(),
-                            ))),
+                            value: Some(Value::Protected(SecStr::new(b"custom-data-value".to_vec()))),
                             last_modification_time: Some("2000-12-31T12:35:03".parse().unwrap()),
                         },
                     ),

--- a/src/xml_db/parse/entry.rs
+++ b/src/xml_db/parse/entry.rs
@@ -36,8 +36,7 @@ impl FromXml for Entry {
                         out.uuid = SimpleTag::<Uuid>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Tags" => {
-                        if let Some(tags) =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value
+                        if let Some(tags) = SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value
                         {
                             out.tags = tags
                                 .split(|c| c == ';' || c == ',')
@@ -66,8 +65,7 @@ impl FromXml for Entry {
                         out.times = Times::from_xml(iterator, inner_cipher)?;
                     }
                     "IconID" => {
-                        out.icon_id =
-                            SimpleTag::<Option<usize>>::from_xml(iterator, inner_cipher)?.value;
+                        out.icon_id = SimpleTag::<Option<usize>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "CustomIconUUID" => {
                         out.custom_icon_uuid =
@@ -82,12 +80,10 @@ impl FromXml for Entry {
                             SimpleTag::<Option<Color>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "OverrideURL" => {
-                        out.override_url =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                        out.override_url = SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "QualityCheck" => {
-                        out.quality_check =
-                            SimpleTag::<Option<bool>>::from_xml(iterator, inner_cipher)?.value;
+                        out.quality_check = SimpleTag::<Option<bool>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "History" => {
                         out.history = Some(History::from_xml(iterator, inner_cipher)?);
@@ -236,8 +232,7 @@ impl FromXml for Value {
                     .map(|v| v.to_lowercase().parse::<bool>())
                     .unwrap_or(Ok(false))?;
 
-                let content =
-                    Option::<String>::from_xml(iterator, inner_cipher)?.unwrap_or(String::new());
+                let content = Option::<String>::from_xml(iterator, inner_cipher)?.unwrap_or(String::new());
 
                 let value = if protected {
                     let buf = base64_engine::STANDARD.decode(&content)?;
@@ -290,12 +285,10 @@ impl FromXml for AutoType {
                         out.enabled = SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "DefaultSequence" => {
-                        out.sequence =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                        out.sequence = SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "DataTransferObfuscation" => {
-                        let _value =
-                            SimpleTag::<Option<usize>>::from_xml(iterator, inner_cipher)?.value;
+                        let _value = SimpleTag::<Option<usize>>::from_xml(iterator, inner_cipher)?.value;
                         // TODO probably not needed?
                     }
                     "Association" => {
@@ -344,12 +337,10 @@ impl FromXml for AutoTypeAssociation {
             match event {
                 SimpleXmlEvent::Start(name, _) => match &name[..] {
                     "Window" => {
-                        out.window =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                        out.window = SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "KeystrokeSequence" => {
-                        out.sequence =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                        out.sequence = SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     _ => {
                         IgnoreSubfield::from_xml(iterator, inner_cipher)?;

--- a/src/xml_db/parse/group.rs
+++ b/src/xml_db/parse/group.rs
@@ -34,12 +34,10 @@ impl FromXml for Group {
                         out.name = SimpleTag::<String>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Notes" => {
-                        out.notes =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                        out.notes = SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "IconID" => {
-                        out.icon_id =
-                            SimpleTag::<Option<usize>>::from_xml(iterator, inner_cipher)?.value;
+                        out.icon_id = SimpleTag::<Option<usize>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "CustomIconUUID" => {
                         out.custom_icon_uuid =
@@ -49,8 +47,7 @@ impl FromXml for Group {
                         out.times = Times::from_xml(iterator, inner_cipher)?;
                     }
                     "IsExpanded" => {
-                        out.is_expanded =
-                            SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
+                        out.is_expanded = SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "DefaultAutoTypeSequence" => {
                         out.default_autotype_sequence =

--- a/src/xml_db/parse/meta.rs
+++ b/src/xml_db/parse/meta.rs
@@ -34,8 +34,7 @@ impl FromXml for Meta {
             match event {
                 SimpleXmlEvent::Start(name, _) => match &name[..] {
                     "Generator" => {
-                        out.generator =
-                            SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
+                        out.generator = SimpleTag::<Option<String>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "DatabaseName" => {
                         out.database_name =
@@ -43,8 +42,7 @@ impl FromXml for Meta {
                     }
                     "DatabaseNameChanged" => {
                         out.database_name_changed =
-                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?
-                                .value;
+                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "DatabaseDescription" => {
                         out.database_description =
@@ -52,8 +50,7 @@ impl FromXml for Meta {
                     }
                     "DatabaseDescriptionChanged" => {
                         out.database_description_changed =
-                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?
-                                .value;
+                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "DefaultUserName" => {
                         out.default_username =
@@ -61,21 +58,18 @@ impl FromXml for Meta {
                     }
                     "DefaultUserNameChanged" => {
                         out.default_username_changed =
-                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?
-                                .value;
+                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "MaintenanceHistoryDays" => {
                         out.maintenance_history_days =
                             SimpleTag::<Option<usize>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Color" => {
-                        out.color =
-                            SimpleTag::<Option<Color>>::from_xml(iterator, inner_cipher)?.value;
+                        out.color = SimpleTag::<Option<Color>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "MasterKeyChanged" => {
                         out.master_key_changed =
-                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?
-                                .value;
+                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "MasterKeyChangeRec" => {
                         out.master_key_change_rec =
@@ -86,8 +80,7 @@ impl FromXml for Meta {
                             SimpleTag::<Option<isize>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "MemoryProtection" => {
-                        out.memory_protection =
-                            Some(MemoryProtection::from_xml(iterator, inner_cipher)?);
+                        out.memory_protection = Some(MemoryProtection::from_xml(iterator, inner_cipher)?);
                     }
                     "CustomIcons" => {
                         out.custom_icons = CustomIcons::from_xml(iterator, inner_cipher)?;
@@ -102,8 +95,7 @@ impl FromXml for Meta {
                     }
                     "RecycleBinChanged" => {
                         out.recyclebin_changed =
-                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?
-                                .value;
+                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "EntryTemplatesGroup" => {
                         out.entry_templates_group =
@@ -111,8 +103,7 @@ impl FromXml for Meta {
                     }
                     "EntryTemplatesGroupChanged" => {
                         out.entry_templates_group_changed =
-                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?
-                                .value;
+                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "LastSelectedGroup" => {
                         out.last_selected_group =
@@ -132,8 +123,7 @@ impl FromXml for Meta {
                     }
                     "SettingsChanged" => {
                         out.settings_changed =
-                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?
-                                .value;
+                            SimpleTag::<Option<NaiveDateTime>>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "Binaries" => {
                         out.binaries = BinaryAttachments::from_xml(iterator, inner_cipher)?;
@@ -185,24 +175,19 @@ impl FromXml for MemoryProtection {
             match event {
                 SimpleXmlEvent::Start(name, _) => match &name[..] {
                     "ProtectTitle" => {
-                        out.protect_title =
-                            SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
+                        out.protect_title = SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "ProtectUserName" => {
-                        out.protect_username =
-                            SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
+                        out.protect_username = SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "ProtectPassword" => {
-                        out.protect_password =
-                            SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
+                        out.protect_password = SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "ProtectURL" => {
-                        out.protect_url =
-                            SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
+                        out.protect_url = SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
                     }
                     "ProtectNotes" => {
-                        out.protect_notes =
-                            SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
+                        out.protect_notes = SimpleTag::<bool>::from_xml(iterator, inner_cipher)?.value;
                     }
                     _ => {
                         IgnoreSubfield::from_xml(iterator, inner_cipher)?;
@@ -280,29 +265,28 @@ impl FromXml for BinaryAttachment {
         let open_tag = iterator.next().ok_or(XmlParseError::Eof)?;
 
         let mut out = Self::default();
-        let (identifier, compressed) =
-            if let SimpleXmlEvent::Start(ref name, ref attributes) = open_tag {
-                if name != "Binary" {
-                    return Err(XmlParseError::BadEvent {
-                        expected: "Open Binary tag",
-                        event: open_tag,
-                    });
-                }
-
-                let identifier = attributes.get("ID").map(|s| s.to_string());
-
-                let compressed = attributes
-                    .get("Compressed")
-                    .map(|v| v.to_lowercase().parse())
-                    .unwrap_or(Ok(false))?;
-
-                (identifier, compressed)
-            } else {
+        let (identifier, compressed) = if let SimpleXmlEvent::Start(ref name, ref attributes) = open_tag {
+            if name != "Binary" {
                 return Err(XmlParseError::BadEvent {
                     expected: "Open Binary tag",
                     event: open_tag,
                 });
-            };
+            }
+
+            let identifier = attributes.get("ID").map(|s| s.to_string());
+
+            let compressed = attributes
+                .get("Compressed")
+                .map(|v| v.to_lowercase().parse())
+                .unwrap_or(Ok(false))?;
+
+            (identifier, compressed)
+        } else {
+            return Err(XmlParseError::BadEvent {
+                expected: "Open Binary tag",
+                event: open_tag,
+            });
+        };
 
         let data = String::from_xml(iterator, inner_cipher)?;
         let buf = base64_engine::STANDARD.decode(&data)?;
@@ -420,9 +404,7 @@ impl FromXml for Icon {
 mod parse_meta_test {
 
     use crate::{
-        db::meta::{
-            BinaryAttachment, BinaryAttachments, CustomIcons, Icon, MemoryProtection, Meta,
-        },
+        db::meta::{BinaryAttachment, BinaryAttachments, CustomIcons, Icon, MemoryProtection, Meta},
         xml_db::parse::{parse_test::parse_test_xml, XmlParseError},
     };
 
@@ -456,14 +438,12 @@ mod parse_meta_test {
         let value = parse_test_xml::<MemoryProtection>("<MemoryProtection></TestTag>");
         assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
 
-        let value = parse_test_xml::<MemoryProtection>(
-            "<MemoryProtection>No-Characters-Allowed</MemoryProtection>",
-        );
+        let value =
+            parse_test_xml::<MemoryProtection>("<MemoryProtection>No-Characters-Allowed</MemoryProtection>");
         assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
 
-        let _value = parse_test_xml::<MemoryProtection>(
-            "<MemoryProtection><UnkownChildTag/></MemoryProtection>",
-        )?;
+        let _value =
+            parse_test_xml::<MemoryProtection>("<MemoryProtection><UnkownChildTag/></MemoryProtection>")?;
 
         Ok(())
     }
@@ -478,8 +458,7 @@ mod parse_meta_test {
         let value = parse_test_xml::<BinaryAttachments>("<Binaries></TestTag>");
         assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
 
-        let value =
-            parse_test_xml::<BinaryAttachments>("<Binaries>No-Characters-Allowed</Binaries>");
+        let value = parse_test_xml::<BinaryAttachments>("<Binaries>No-Characters-Allowed</Binaries>");
         assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
 
         let _value = parse_test_xml::<BinaryAttachments>("<Binaries><UnkownChildTag/></Binaries>")?;
@@ -489,8 +468,7 @@ mod parse_meta_test {
 
     #[test]
     fn test_binary_attachment() -> Result<(), XmlParseError> {
-        let value =
-            parse_test_xml::<BinaryAttachment>("<Binary ID=\"1\">QmluYXJ5IERhdGE=</Binary>")?;
+        let value = parse_test_xml::<BinaryAttachment>("<Binary ID=\"1\">QmluYXJ5IERhdGE=</Binary>")?;
         assert_eq!(value.identifier, Some("1".to_string()));
         assert_eq!(value.content, r"Binary Data".as_bytes());
 
@@ -522,8 +500,7 @@ mod parse_meta_test {
         let value = parse_test_xml::<CustomIcons>("<CustomIcons></TestTag>");
         assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
 
-        let value =
-            parse_test_xml::<CustomIcons>("<CustomIcons>No-Characters-Allowed</CustomIcons>");
+        let value = parse_test_xml::<CustomIcons>("<CustomIcons>No-Characters-Allowed</CustomIcons>");
         assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
 
         let _value = parse_test_xml::<CustomIcons>("<CustomIcons><UnkownChildTag/></CustomIcons>")?;

--- a/tests/entry_tests.rs
+++ b/tests/entry_tests.rs
@@ -26,9 +26,7 @@ mod entry_tests {
             assert_eq!(e.get("URL"), Some("http://keepass.info/"));
             assert_eq!(e.times.expires, false);
 
-            let et =
-                chrono::NaiveDateTime::parse_from_str("2016-01-06 09:43:01", "%Y-%m-%d %H:%M:%S")
-                    .unwrap();
+            let et = chrono::NaiveDateTime::parse_from_str("2016-01-06 09:43:01", "%Y-%m-%d %H:%M:%S").unwrap();
             assert_eq!(e.get_expiry_time(), Some(&et));
             assert_eq!(e.get_time("ExpiryTime"), Some(&et));
 

--- a/tests/file_read_tests.rs
+++ b/tests/file_read_tests.rs
@@ -285,10 +285,7 @@ mod file_read_tests {
     #[test]
     fn open_kdb_with_password() -> Result<(), DatabaseOpenError> {
         let path = Path::new("tests/resources/test_db_kdb_with_password.kdb");
-        let db = Database::open(
-            &mut File::open(path)?,
-            DatabaseKey::new().with_password("foobar"),
-        )?;
+        let db = Database::open(&mut File::open(path)?, DatabaseKey::new().with_password("foobar"))?;
 
         println!("{:?} DB Opened", db);
         assert_eq!(db.root.name, "Root");


### PR DESCRIPTION
I've been wanting to do that for a while. The default `max_width` for `rustfmt` is 100, which results in many split lines, given the verbosity of Rust. The PR should not be too difficult to review, but you don't have to trust me. You can copy the `rustfmt.toml` file and run the following script, and you should get to the same result:
```
#!/usr/bin/env bash
files=$(find . -name '*.rs')
IFS=$'\n'; for file in $files; do
    rustfmt "$file"
done
```