### PR TITLE
refactor: allow owned path when searching for node

### DIFF
--- a/src/db/node.rs
+++ b/src/db/node.rs
@@ -2,45 +2,6 @@ use std::collections::VecDeque;
 
 use crate::db::{entry::Entry, group::Group};
 
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub(crate) enum NodePathElement<'a> {
-    #[allow(dead_code)]
-    UUID(&'a str),
-    Title(&'a str),
-}
-
-pub(crate) type NodePath<'a> = Vec<NodePathElement<'a>>;
-
-impl<'a> NodePathElement<'_> {
-    pub(crate) fn matches(&self, node: &Node) -> bool {
-        let uuid = match node {
-            Node::Entry(e) => e.uuid,
-            Node::Group(g) => g.uuid,
-        };
-        let title = match node {
-            Node::Entry(e) => e.get_title(),
-            Node::Group(g) => Some(g.get_name()),
-        };
-        match self {
-            NodePathElement::UUID(u) => uuid.to_string() == *u,
-            NodePathElement::Title(t) => {
-                if let Some(title) = title {
-                    return title == *t;
-                }
-                return false;
-            }
-        }
-    }
-
-    pub(crate) fn wrap_titles(path: &[&'a str]) -> NodePath<'a> {
-        let mut response: NodePath = vec![];
-        for path_element in path {
-            response.push(NodePathElement::Title(path_element));
-        }
-        response
-    }
-}
-
 /// An owned node in the database tree structure which can either be an Entry or Group
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]


### PR DESCRIPTION
I initially wrote the `NodePathElement` abstraction to make it possible to use the `get` and `get_mut` functions with either titles or UUIDs. However, this abstraction makes it difficult to allow both owned strings and string references for the node path. This PR instead introduces a simpler `SearchField` enum, which is passed separately to the `get_internal` and `get_mut_internal` functions. This makes it possible to use `AsRef<str>` with the internal functions, thus allowing an owned path to be provided when searching for a node.

Note that I didn't migrate the `get` and `get_mut` functions to `AsRef<str>` yet, since this would be a breaking change. This can be done later in a separate commit, which should also include migration notes for users of the library. Using `AsRef<str>` is also slightly less ergonomic because sometimes the type has to be provided explicitly, if the compiler cannot infer it. I'm thinking about providing one function with an explicit type, and another with `AsRef<str>`.