### PR TITLE
feat: make Database cloneable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ const SALSA_20: u32 = 2;
 const CHA_CHA_20: u32 = 3;
 
 /// Configuration of how a database should be stored
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct DatabaseConfig {
     /// Version of the outer database file

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 
 /// A decrypted KeePass database
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 pub struct Database {
     /// Configuration settings of the database such as encryption and compression algorithms


### PR DESCRIPTION
I don't see a reason why Database could be not cloneable, since Entry, Group and even DatabaseKey already are.