### PR TITLE
feat: add DatabaseKey::is_empty fn

### DIFF
--- a/src/bin/kp-dump-json.rs
+++ b/src/bin/kp-dump-json.rs
@@ -15,6 +15,10 @@ struct Args {
     /// Provide a keyfile
     #[arg(short = 'k', long)]
     keyfile: Option<String>,
+
+    /// Do not use a password to decrypt the database
+    #[arg(short = 'n', long)]
+    no_password: bool,
 }
 
 pub fn main() -> Result<()> {
@@ -27,7 +31,13 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    key = key.with_password_from_prompt("Password (or blank for none): ")?;
+    if !args.no_password {
+        key = key.with_password_from_prompt("Password: ")?;
+    }
+
+    if key.is_empty() {
+        return Err(anyhow::format_err!("No database key was provided."));
+    }
 
     let db = Database::open(&mut source, key)?;
 

--- a/src/bin/kp-dump-xml.rs
+++ b/src/bin/kp-dump-xml.rs
@@ -19,6 +19,10 @@ struct Args {
     /// Provide a keyfile
     #[arg(short = 'k', long)]
     keyfile: Option<String>,
+
+    /// Do not use a password to decrypt the database
+    #[arg(short = 'n', long)]
+    no_password: bool,
 }
 
 pub fn main() -> Result<()> {
@@ -31,7 +35,13 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    key = key.with_password_from_prompt("Password (or blank for none): ")?;
+    if !args.no_password {
+        key = key.with_password_from_prompt("Password: ")?;
+    }
+
+    if key.is_empty() {
+        return Err(anyhow::format_err!("No database key was provided."));
+    }
 
     let xml = Database::get_xml(&mut source, key)?;
 

--- a/src/bin/kp-purge-history.rs
+++ b/src/bin/kp-purge-history.rs
@@ -15,6 +15,10 @@ struct Args {
     /// Provide a keyfile
     #[arg(short = 'k', long)]
     keyfile: Option<String>,
+
+    /// Do not use a password to decrypt the database
+    #[arg(short = 'n', long)]
+    no_password: bool,
 }
 
 pub fn main() -> Result<()> {
@@ -27,7 +31,13 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    key = key.with_password_from_prompt("Password (or blank for none): ")?;
+    if !args.no_password {
+        key = key.with_password_from_prompt("Password: ")?;
+    }
+
+    if key.is_empty() {
+        return Err(anyhow::format_err!("No database key was provided."));
+    }
 
     let mut db = Database::open(&mut source, key.clone())?;
 

--- a/src/bin/kp-rewrite.rs
+++ b/src/bin/kp-rewrite.rs
@@ -18,6 +18,10 @@ struct Args {
     /// Provide a keyfile
     #[arg(short = 'k', long)]
     keyfile: Option<String>,
+
+    /// Do not use a password to decrypt the database
+    #[arg(short = 'n', long)]
+    no_password: bool,
 }
 
 pub fn main() -> Result<()> {
@@ -30,7 +34,13 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    key = key.with_password_from_prompt("Password (or blank for none): ")?;
+    if !args.no_password {
+        key = key.with_password_from_prompt("Password: ")?;
+    }
+
+    if key.is_empty() {
+        return Err(anyhow::format_err!("No database key was provided."));
+    }
 
     let db = Database::open(&mut source, key.clone())?;
 

--- a/src/bin/kp-show-db.rs
+++ b/src/bin/kp-show-db.rs
@@ -15,6 +15,10 @@ struct Args {
     /// Provide a keyfile
     #[arg(short = 'k', long)]
     keyfile: Option<String>,
+
+    /// Do not use a password to decrypt the database
+    #[arg(short = 'n', long)]
+    no_password: bool,
 }
 
 pub fn main() -> Result<()> {
@@ -27,7 +31,13 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    key = key.with_password_from_prompt("Password (or blank for none): ")?;
+    if !args.no_password {
+        key = key.with_password_from_prompt("Password: ")?;
+    }
+
+    if key.is_empty() {
+        return Err(anyhow::format_err!("No database key was provided."));
+    }
 
     let db = Database::open(&mut source, key)?;
 

--- a/src/bin/kp-show-otp.rs
+++ b/src/bin/kp-show-otp.rs
@@ -15,6 +15,10 @@ struct Args {
     #[arg(short = 'k', long)]
     keyfile: Option<String>,
 
+    /// Do not use a password to decrypt the database
+    #[arg(short = 'n', long)]
+    no_password: bool,
+
     /// Provide the entry to read
     entry: String,
 }
@@ -29,7 +33,13 @@ pub fn main() -> Result<()> {
         key = key.with_keyfile(&mut File::open(f)?)?;
     }
 
-    key = key.with_password_from_prompt("Password (or blank for none): ")?;
+    if !args.no_password {
+        key = key.with_password_from_prompt("Password: ")?;
+    }
+
+    if key.is_empty() {
+        return Err(anyhow::format_err!("No database key was provided."));
+    }
 
     let db = Database::open(&mut source, key)?;
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -101,10 +101,6 @@ impl DatabaseKey {
     #[cfg(feature = "utilities")]
     pub fn with_password_from_prompt(mut self, prompt_message: &str) -> Result<Self, std::io::Error> {
         self.password = Some(rpassword::prompt_password(prompt_message)?);
-        // FIXME This prevents using an empty password when using the password prompt.
-        if self.password == Some("".to_string()) {
-            self.password = None;
-        }
         Ok(self)
     }
 
@@ -162,6 +158,18 @@ impl DatabaseKey {
         }
 
         Ok(out)
+    }
+
+    /// Returns true if the database key is not associated with any key component.
+    pub fn is_empty(&self) -> bool {
+        if self.password.is_some() || self.keyfile.is_some() {
+            return false;
+        }
+        #[cfg(feature = "challenge_response")]
+        if self.challenge_response_key.is_some() {
+            return false;
+        }
+        true
     }
 }
 


### PR DESCRIPTION
This also fixes a bug with the `with_password_from_prompt` function that prevented users from entering an empty password.

BREAKING CHANGE: an empty password is no longer converted to a database key with no password when using the command-line utilities. The `--no-password` option has to be used to open a database without a password.