### PR TITLE
fix: trigger new minor version

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -44,11 +44,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: paulhatch/semantic-version@976ff820fcdca81ffc95e385a07b7eff05ddccc3
+      - uses: paulhatch/semantic-version@e528d273e7da55ef59a0987c2ad7b8bcbc09698e
         id: semantic-version
         with:
           tag_prefix: "v"
-          major_pattern: "/^breaking change:/"
+          major_pattern: "/breaking change:/"
           major_regexp_flags: "ig"
           minor_pattern: "/^feat:/"
           minor_regexp_flags: "ig"


### PR DESCRIPTION
The last commit didn't trigger a new minor release as expected. I think it's because of how the regex is configured, since I've seen instances of a minor version being created when the breaking change description is at the beginning of the commit message.

BREAKING CHANGE: This commit trigger a minor release version which should have been generated for commit 229fe57c7d0fc50b8f9c3f6c4a117a245a1739eb