### PR TITLE
fix(aes): use consistent block padding

### DIFF
--- a/src/crypt/ciphers.rs
+++ b/src/crypt/ciphers.rs
@@ -42,7 +42,7 @@ impl Cipher for AES256Cipher {
     fn encrypt(&mut self, plaintext: &[u8]) -> Result<Vec<u8>, CryptographyError> {
         let cipher = Aes256CbcEncryptor::new_from_slices(&self.key, &self.iv)?;
 
-        let ciphertext = cipher.encrypt_padded_vec_mut::<twofish::cipher::block_padding::Pkcs7>(plaintext);
+        let ciphertext = cipher.encrypt_padded_vec_mut::<Pkcs7>(plaintext);
 
         Ok(ciphertext)
     }


### PR DESCRIPTION
I tried searching for a reason why we would be using twofish padding for aes, but that change [dates all the way back to the initial PR ](https://github.com/sseemayer/keepass-rs/commit/3e8cad4b2bada7e43ca9955cdce9695b16087ecd#diff-286faac43a94819c5cf02776804fb5dc7a63bcddc8f2fb7c99d6346277856683R40), so I'm pretty sure it was just my mistake. I don't think this changes anything anyway since in the end they are both using `Pkcs7`, but I just feel like it's less confusing and more consistent with the decryption function to reference `Pkcs7` directly.