### PR TITLE
chore: bump code coverage tool versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:0.27.1
+      image: xd009642/tarpaulin:0.28.0
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -22,17 +22,19 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:0.27.1
+      image: xd009642/tarpaulin:0.28.0
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4
       - name: Generate code coverage
         run: |
           cargo tarpaulin --verbose --timeout 120
-      - uses: codecov/codecov-action@v3
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   get-next-version:
     name: Get the next version


### PR DESCRIPTION
Updates tarpaulin to 0.28.0 and the codecov-action to v4

Closes #222 