### PR TITLE
feat: pin only major and minor versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,12 +74,12 @@ serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }
 
 # dependencies for totp (enabled by "totp" feature)
-totp-lite = { version = "2.0.0", optional = true }
-url = { version = "2.2.2", optional = true }
+totp-lite = { version = "2.0", optional = true }
+url = { version = "2.2", optional = true }
 base32 = { version = "0.5", optional = true }
 
 [dev-dependencies]
-rustfmt = "0.10.0"
+rustfmt = "0.10"
 
 [[bin]]
 # parse a KeePass database and output as a JSON document


### PR DESCRIPTION
I don't think it makes sense to pin the patch versions since this project is mainly used as a library.