### PR TITLE
chore: fix chrono deprecation warnings

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -202,8 +202,8 @@ impl Times {
     // Returns the current time, without the nanoseconds since
     // the last leap second.
     pub fn now() -> NaiveDateTime {
-        let now = chrono::Utc::now().naive_utc().timestamp();
-        chrono::NaiveDateTime::from_timestamp(now, 0)
+        let now = chrono::Utc::now().timestamp();
+        chrono::DateTime::from_timestamp(now, 0).unwrap().naive_utc()
     }
 
     pub fn new() -> Times {


### PR DESCRIPTION
I don't think there's an issue with using `unwrap` here, since we have just created the timestamp so it must be valid.