### PR TITLE
chore: add unit test for empty group name

### DIFF
--- a/src/xml_db/parse/group.rs
+++ b/src/xml_db/parse/group.rs
@@ -115,6 +115,9 @@ mod parse_group_test {
         let value = parse_test_xml::<Group>("");
         assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
 
+        let value = parse_test_xml::<Group>("<Group><Name></Name></Group>")?;
+        assert_eq!(value.name, "".to_string());
+
         let value = parse_test_xml::<Group>("<TestTag>SomeData</TestTag>");
         assert!(matches!(value, Err(XmlParseError::BadEvent { .. })));
 


### PR DESCRIPTION
This PR adds a unit tests for empty group names, supported since https://github.com/sseemayer/keepass-rs/pull/234