### PR TITLE
chore: allow longer lines in commit messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: commitlintrc.json
 
   doc:
     name: Build Doc

--- a/commitlintrc.json
+++ b/commitlintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+
+  "helpUrl": "https://github.com/conventional-changelog/commitlint/#what-is-commitlint",
+
+  "rules": {
+    "body-max-line-length": [2, "always", 4096]
+  }
+}


### PR DESCRIPTION
The 100 character limit in the commit body is very limiting, especially when we want to include URLs. This PR should make the situation slightly better, although I think in the future we should completely disable the line length check if a line is found to contain a URL. This would also allow us to preserve a smaller length limit for lines that do not container a URL.