### PR TITLE
feat: switch to nusb for challenge-response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ cipher = { version = "0.4", features = ["std"] }
 twofish = "0.7"
 cbc = "0.1"
 
-challenge_response = { version = "0.5", optional = true }
+challenge_response = { version = "0.5", optional = true, default-features = false, features = ["nusb"] }
 
 uuid = { version = "1.2", features = ["v4", "serde"] }
 hex = { version = "0.4" }


### PR DESCRIPTION
This will remove the dependency on libusb for keepass-rs when the challenge-response feature is enabled.