### PR TITLE
fix(test): feature-gate roundtrip tests

### DIFF
--- a/tests/large_database_roundtrip_tests.rs
+++ b/tests/large_database_roundtrip_tests.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "save_kdbx4")]
 mod large_file_roundtrip_tests {
     use std::fs::File;
 
@@ -39,10 +40,8 @@ mod large_file_roundtrip_tests {
 
         // Define database key.
         let key = DatabaseKey::new().with_password(TEST_DATABASE_PASSWORD);
-        #[cfg(feature = "save_kdbx4")]
-        {
-            db.save(&mut File::create(TEST_DATABASE_FILE_NAME)?, key.clone())?;
-        }
+        db.save(&mut File::create(TEST_DATABASE_FILE_NAME)?, key.clone())?;
+
         // Read the database that was written in the previous block.
         let db = Database::open(&mut File::open(TEST_DATABASE_FILE_NAME)?, key)?;
         // Validate that the data is what we expect.


### PR DESCRIPTION
The roundtrip tests can only succeed if the database to be parsed in the
test has been successfully generated at least one time, so tests will
fail when the project was freshly cloned and the tests are run with the
database missing.

Put the whole roundtrip test module behind a feature gate, so that we
test writing and reading at the same time.
