### PR TITLE
chore: bump getrandom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ challenge_response = { version = "0.5", optional = true }
 
 uuid = { version = "1.2", features = ["v4", "serde"] }
 hex = { version = "0.4" }
-getrandom = { version = "0.2", features = ["std"] }
+getrandom = { version = "0.3", features = ["std"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 # dependencies for command-line utilities

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,7 +236,7 @@ impl KdfConfig {
     #[cfg(feature = "save_kdbx4")]
     pub(crate) fn get_kdf_and_seed(&self) -> Result<(Box<dyn kdf::Kdf>, Vec<u8>), getrandom::Error> {
         let mut kdf_seed = vec![0; self.seed_size()];
-        getrandom::getrandom(&mut kdf_seed)?;
+        getrandom::fill(&mut kdf_seed)?;
 
         let kdf = self.get_kdf_seeded(&kdf_seed);
 

--- a/src/format/kdbx4/dump.rs
+++ b/src/format/kdbx4/dump.rs
@@ -33,13 +33,13 @@ pub fn dump_kdbx4(
 
     // generate encryption keys and seeds on the fly when saving
     let mut master_seed = vec![0; HEADER_MASTER_SEED_SIZE];
-    getrandom::getrandom(&mut master_seed)?;
+    getrandom::fill(&mut master_seed)?;
 
     let mut outer_iv = vec![0; db.config.outer_cipher_config.get_iv_size()];
-    getrandom::getrandom(&mut outer_iv)?;
+    getrandom::fill(&mut outer_iv)?;
 
     let mut inner_random_stream_key = vec![0; db.config.inner_cipher_config.get_key_size()];
-    getrandom::getrandom(&mut inner_random_stream_key)?;
+    getrandom::fill(&mut inner_random_stream_key)?;
 
     let (kdf, kdf_seed) = db.config.kdf_config.get_kdf_and_seed()?;
 

--- a/src/format/kdbx4/mod.rs
+++ b/src/format/kdbx4/mod.rs
@@ -81,7 +81,7 @@ mod kdbx4_tests {
         let mut password_bytes: Vec<u8> = vec![];
         let mut password: String = "".to_string();
         password_bytes.resize(40, 0);
-        getrandom::getrandom(&mut password_bytes).unwrap();
+        getrandom::fill(&mut password_bytes).unwrap();
         for random_char in password_bytes {
             password += &std::char::from_u32(random_char as u32).unwrap().to_string();
         }
@@ -122,7 +122,7 @@ mod kdbx4_tests {
         let mut password_bytes: Vec<u8> = vec![];
         let mut password: String = "".to_string();
         password_bytes.resize(40, 0);
-        getrandom::getrandom(&mut password_bytes).unwrap();
+        getrandom::fill(&mut password_bytes).unwrap();
         for random_char in password_bytes {
             password += &std::char::from_u32(random_char as u32).unwrap().to_string();
         }

--- a/src/xml_db/mod.rs
+++ b/src/xml_db/mod.rs
@@ -33,7 +33,7 @@ mod tests {
         let mut password_bytes: Vec<u8> = vec![];
         let mut password: String = "".to_string();
         password_bytes.resize(40, 0);
-        getrandom::getrandom(&mut password_bytes).unwrap();
+        getrandom::fill(&mut password_bytes).unwrap();
         for random_char in password_bytes {
             password += &std::char::from_u32(random_char as u32).unwrap().to_string();
         }


### PR DESCRIPTION
`getrandom` was renamed to `fill`, [as seen in the CHANGELOG](https://github.com/rust-random/getrandom/blob/master/CHANGELOG.md#breaking-changes)