### PR TITLE
fix(deps): bump hex-literal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:0.31.2
+      image: xd009642/tarpaulin:0.32.3
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -22,7 +22,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:0.31.2
+      image: xd009642/tarpaulin:0.32.3
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ byteorder = "1"
 flate2 = "1"
 xml-rs = "0.8"
 base64 = "0.22"
-hex-literal = "0.4"
+hex-literal = "1"
 secstr = "0.5"
 chrono = { version = "0.4.23", default-features = false, features = [
     "serde",


### PR DESCRIPTION
I also had to bump the tarpaulin image version since the older cargo version does not support the 2024 edition