### PR TITLE
feat(kdbx4): handle public custom data in outer header

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,9 @@ pub struct DatabaseConfig {
 
     /// Settings for the Key Derivation Function (KDF)
     pub kdf_config: KdfConfig,
+
+    /// Custom data of plugins/ports.
+    pub public_custom_data: Option<VariantDictionary>,
 }
 
 /// Sensible default configuration for new databases
@@ -65,6 +68,7 @@ impl Default for DatabaseConfig {
                 parallelism: 4,
                 version: argon2::Version::Version13,
             },
+            public_custom_data: None,
         }
     }
 }

--- a/src/format/kdb.rs
+++ b/src/format/kdb.rs
@@ -349,6 +349,7 @@ pub(crate) fn parse_kdb(data: &[u8], db_key: &DatabaseKey) -> Result<Database, D
         compression_config: CompressionConfig::None,
         inner_cipher_config: InnerCipherConfig::Plain,
         kdf_config,
+        public_custom_data: Default::default(),
     };
 
     Ok(Database {

--- a/src/format/kdbx3.rs
+++ b/src/format/kdbx3.rs
@@ -201,6 +201,7 @@ pub(crate) fn decrypt_kdbx3(
         compression_config: header.compression,
         inner_cipher_config: header.inner_cipher,
         kdf_config: header.kdf_config,
+        public_custom_data: Default::default(),
     };
 
     let mut pos = header.body_start;

--- a/src/format/kdbx4/dump.rs
+++ b/src/format/kdbx4/dump.rs
@@ -21,6 +21,8 @@ use crate::{
     variant_dictionary::VariantDictionary,
 };
 
+use super::HEADER_PUBLIC_CUSTOM_DATA;
+
 /// Dump a KeePass database using the key elements
 pub fn dump_kdbx4(
     db: &Database,
@@ -56,6 +58,7 @@ pub fn dump_kdbx4(
         outer_iv: outer_iv.clone(),
         kdf_config: db.config.kdf_config.clone(),
         kdf_seed,
+        public_custom_data: db.config.public_custom_data.clone(),
     }
     .dump(&mut header_data)?;
 
@@ -148,6 +151,14 @@ impl KDBX4OuterHeader {
 
         writer.write_u8(HEADER_END)?;
         writer.write_with_len(&[])?;
+
+        if let Some(pcd) = &self.public_custom_data {
+            let mut vd_buffer = Vec::new();
+            pcd.dump(&mut vd_buffer)?;
+
+            writer.write_u8(HEADER_PUBLIC_CUSTOM_DATA)?;
+            writer.write_with_len(&vd_buffer)?;
+        }
 
         Ok(())
     }

--- a/src/format/kdbx4/mod.rs
+++ b/src/format/kdbx4/mod.rs
@@ -29,6 +29,8 @@ pub const HEADER_MASTER_SEED: u8 = 4;
 pub const HEADER_ENCRYPTION_IV: u8 = 7;
 /// Parameters for the key derivation function
 pub const HEADER_KDF_PARAMS: u8 = 11;
+/// Custom data of plugins/ports.
+pub const HEADER_PUBLIC_CUSTOM_DATA: u8 = 12;
 
 /// Inner header entry denoting the end of the inner header
 pub const INNER_HEADER_END: u8 = 0x00;

--- a/src/format/kdbx4/mod.rs
+++ b/src/format/kdbx4/mod.rs
@@ -5,6 +5,7 @@ mod parse;
 use crate::{
     config::{CompressionConfig, InnerCipherConfig, KdfConfig, OuterCipherConfig},
     format::DatabaseVersion,
+    variant_dictionary::VariantDictionary,
 };
 
 #[cfg(feature = "save_kdbx4")]
@@ -49,6 +50,7 @@ struct KDBX4OuterHeader {
     outer_iv: Vec<u8>,
     kdf_config: KdfConfig,
     kdf_seed: Vec<u8>,
+    public_custom_data: Option<VariantDictionary>,
 }
 
 struct KDBX4InnerHeader {
@@ -187,6 +189,7 @@ mod kdbx4_tests {
                             compression_config: compression_config.clone(),
                             inner_cipher_config: inner_cipher_config.clone(),
                             kdf_config: kdf_config.clone(),
+                            public_custom_data: Default::default(),
                         };
 
                         println!("Testing with config: {config:?}");

--- a/src/format/kdbx4/parse.rs
+++ b/src/format/kdbx4/parse.rs
@@ -10,8 +10,9 @@ use crate::{
     format::{
         kdbx4::{
             KDBX4OuterHeader, HEADER_COMMENT, HEADER_COMPRESSION_ID, HEADER_ENCRYPTION_IV, HEADER_END,
-            HEADER_KDF_PARAMS, HEADER_MASTER_SEED, HEADER_OUTER_ENCRYPTION_ID, INNER_HEADER_BINARY_ATTACHMENTS,
-            INNER_HEADER_END, INNER_HEADER_RANDOM_STREAM_ID, INNER_HEADER_RANDOM_STREAM_KEY,
+            HEADER_KDF_PARAMS, HEADER_MASTER_SEED, HEADER_OUTER_ENCRYPTION_ID, HEADER_PUBLIC_CUSTOM_DATA,
+            INNER_HEADER_BINARY_ATTACHMENTS, INNER_HEADER_END, INNER_HEADER_RANDOM_STREAM_ID,
+            INNER_HEADER_RANDOM_STREAM_KEY,
         },
         DatabaseVersion,
     },
@@ -188,6 +189,10 @@ fn parse_outer_header(data: &[u8]) -> Result<(KDBX4OuterHeader, usize), Database
                 let (kconf, kseed) = vd.try_into()?;
                 kdf_config = Some(kconf);
                 kdf_seed = Some(kseed)
+            }
+
+            HEADER_PUBLIC_CUSTOM_DATA => {
+                let _ = VariantDictionary::parse(entry_buffer)?;
             }
 
             _ => {

--- a/src/format/kdbx4/parse.rs
+++ b/src/format/kdbx4/parse.rs
@@ -127,6 +127,7 @@ pub(crate) fn decrypt_kdbx4(
         compression_config: outer_header.compression_config,
         inner_cipher_config: inner_header.inner_random_stream,
         kdf_config: outer_header.kdf_config,
+        public_custom_data: outer_header.public_custom_data,
     };
 
     Ok((config, header_attachments, inner_decryptor, xml.to_vec()))
@@ -144,6 +145,7 @@ fn parse_outer_header(data: &[u8]) -> Result<(KDBX4OuterHeader, usize), Database
     let mut outer_iv: Option<Vec<u8>> = None;
     let mut kdf_config: Option<KdfConfig> = None;
     let mut kdf_seed: Option<Vec<u8>> = None;
+    let mut public_custom_data: Option<VariantDictionary> = None;
 
     // parse header
     loop {
@@ -192,7 +194,8 @@ fn parse_outer_header(data: &[u8]) -> Result<(KDBX4OuterHeader, usize), Database
             }
 
             HEADER_PUBLIC_CUSTOM_DATA => {
-                let _ = VariantDictionary::parse(entry_buffer)?;
+                let vd = VariantDictionary::parse(entry_buffer)?;
+                public_custom_data = Some(vd)
             }
 
             _ => {
@@ -229,6 +232,7 @@ fn parse_outer_header(data: &[u8]) -> Result<(KDBX4OuterHeader, usize), Database
             outer_iv,
             kdf_config,
             kdf_seed,
+            public_custom_data,
         },
         pos,
     ))

--- a/src/variant_dictionary.rs
+++ b/src/variant_dictionary.rs
@@ -20,8 +20,9 @@ pub const I64_TYPE_ID: u8 = 0x0d;
 pub const STR_TYPE_ID: u8 = 0x18;
 pub const BYTES_TYPE_ID: u8 = 0x42;
 
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) struct VariantDictionary {
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+pub struct VariantDictionary {
     pub data: HashMap<String, VariantDictionaryValue>,
 }
 
@@ -161,8 +162,9 @@ impl VariantDictionary {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum VariantDictionaryValue {
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+pub enum VariantDictionaryValue {
     UInt32(u32),
     UInt64(u64),
     Bool(bool),


### PR DESCRIPTION
Databases created with KeepassXC now contain a KPXC_PUBLIC_UUID field in the public custom data outer header [1], causing parsing to fail because of an unrecognized outer header field. This change adds support for these fields.

[1] https://keepass.info/help/kb/kdbx.html