### PR TITLE
fix: do not export internal SearchField enum

### DIFF
--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -14,7 +14,7 @@ use crate::db::merge::{MergeError, MergeEvent, MergeEventType, MergeLog};
 #[cfg(feature = "_merge")]
 pub(crate) type NodeLocation = Vec<Uuid>;
 
-pub enum SearchField {
+pub(crate) enum SearchField {
     #[cfg(any(test, feature = "_merge"))]
     Uuid,
     Title,


### PR DESCRIPTION
BREAKING CHANGE: The `SearchField` enum was removed from the public
interface of the crate, as it is intended for internal use only.