### PR TITLE
fix(kdbx4): writing custom data into outer header

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -791,8 +791,13 @@ mod database_tests {
     #[cfg(feature = "save_kdbx4")]
     #[test]
     fn test_save() {
-        use crate::db::Entry;
+        use crate::{db::Entry, variant_dictionary::VariantDictionary};
         let mut db = Database::new(Default::default());
+
+        let mut public_custom_data = VariantDictionary::new();
+        public_custom_data.set("example", 42);
+
+        db.config.public_custom_data = Some(public_custom_data);
 
         db.root.add_child(Entry::new());
         db.root.add_child(Entry::new());

--- a/src/format/kdbx4/dump.rs
+++ b/src/format/kdbx4/dump.rs
@@ -149,9 +149,6 @@ impl KDBX4OuterHeader {
         writer.write_u8(HEADER_KDF_PARAMS)?;
         writer.write_with_len(&vd_buffer)?;
 
-        writer.write_u8(HEADER_END)?;
-        writer.write_with_len(&[])?;
-
         if let Some(pcd) = &self.public_custom_data {
             let mut vd_buffer = Vec::new();
             pcd.dump(&mut vd_buffer)?;
@@ -159,6 +156,9 @@ impl KDBX4OuterHeader {
             writer.write_u8(HEADER_PUBLIC_CUSTOM_DATA)?;
             writer.write_with_len(&vd_buffer)?;
         }
+
+        writer.write_u8(HEADER_END)?;
+        writer.write_with_len(&[])?;
 
         Ok(())
     }


### PR DESCRIPTION
PR #252 introduced a bug where custom data would get written to the
outer header after it had already ended, leading to the opening of
written databases to fail with a header hash mismatch error. this commit
corrects the order of write operations.
