### PR TITLE
chore: bump rust-argon2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ chrono = { version = "0.4.23", default-features = false, features = [
 ] }
 
 # cryptography
-rust-argon2 = "2.0"
+rust-argon2 = "3.0"
 sha1 = { version = "0.10", optional = true }
 sha2 = "0.10"
 aes = "0.8"

--- a/src/crypt/kdf.rs
+++ b/src/crypt/kdf.rs
@@ -56,6 +56,7 @@ impl Kdf for Argon2Kdf {
         composite_key: &GenericArray<u8, U32>,
     ) -> Result<GenericArray<u8, U32>, CryptographyError> {
         let config = argon2::Config {
+            thread_mode: argon2::ThreadMode::Parallel,
             ad: &[],
             hash_length: 32,
             lanes: self.parallelism,


### PR DESCRIPTION
Users can still disable parallelism by setting [the kdf config value](https://github.com/sseemayer/keepass-rs/blob/7f4a27e52a279a1dec0247b4ff1aa2a2f7d0bed6/src/crypt/kdf.rs#L48) to 1, [which will force sequential mode](https://github.com/sru-systems/rust-argon2/commit/d2f26df297e8ad71fc31b47bede67a9a3d7933b4#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR183).