### PR TITLE
bodge attachment support #262

### DIFF
--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -19,6 +19,7 @@ use crate::db::otp::{TOTPError, TOTP};
 pub struct Entry {
     pub uuid: Uuid,
     pub fields: HashMap<String, Value>,
+    pub attachment_refs: HashMap<String, String>,
     pub autotype: Option<AutoType>,
     pub tags: Vec<String>,
 

--- a/src/xml_db/parse/entry.rs
+++ b/src/xml_db/parse/entry.rs
@@ -46,9 +46,10 @@ impl FromXml for Entry {
                         out.custom_data = CustomData::from_xml(iterator, inner_cipher)?;
                     }
                     "Binary" => {
-                        let _field = BinaryField::from_xml(iterator, inner_cipher)?;
-                        // TODO reference into a binary field from the Meta. Might only appear in
-                        // kdbx3
+                        // TODO reference into a binary field from the Meta instead of providing
+                        // a raw reference. see #262
+                        let field = BinaryField::from_xml(iterator, inner_cipher)?;
+                        out.attachment_refs.insert(field.key, field.identifier.to_string());
                     }
                     "AutoType" => {
                         out.autotype = Some(AutoType::from_xml(iterator, inner_cipher)?);


### PR DESCRIPTION
Add support for file attachments, as discussed in #262. This uses method 1 as discussed there. It's a less than ideal implementation, but it's something. This hasn't been fully tested, and I'm not sure if it should be merged, but I wanted to send upstream for discussion if nothing else.