### PR TITLE
refactor: use nix to generate coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,9 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
-    container:
-      image: xd009642/tarpaulin:0.32.3
-      options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v11
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --timeout 120
+          nix develop --command cargo tarpaulin --verbose --timeout 120

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -21,14 +21,12 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
-    container:
-      image: xd009642/tarpaulin:0.32.3
-      options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v11
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --timeout 120
+          nix develop --command cargo tarpaulin --verbose --timeout 120
       - name: Upload code coverage
         uses: codecov/codecov-action@v4
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
               rustc
               rustfmt
               rust-analyzer
+              cargo-tarpaulin
             ];
           };
         }


### PR DESCRIPTION
Instead of using a docker container with scary options, we can now use tarpaulin via the nix flake. This will ensure that the version of the rust toolchain used when generating the coverage report is the same as the one used both locally and (eventually) in the other CI checks.

This also bumps the version of tarpaulin from 0.32.3 to 0.32.8