### PR TITLE
feat: add utility for benchmarking kdf functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,10 @@ required-features = ["utilities", "save_kdbx4", "challenge_response"]
 name = "kp-yk-recover"
 required-features = ["utilities", "save_kdbx4", "challenge_response"]
 
+[[bin]]
+name = "kp-benchmark-kdf"
+required-features = ["utilities"]
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 missing_docs = "warn"

--- a/src/bin/kp-benchmark-kdf.rs
+++ b/src/bin/kp-benchmark-kdf.rs
@@ -1,0 +1,60 @@
+//! Utility for benchmarking Key Derivation Functions
+use std::time::Duration;
+
+use clap::{Parser, ValueEnum};
+use keepass::crypt::kdf::{AesKdf, Argon2Kdf, Kdf};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// KDF to benchmark
+    #[arg(value_enum)]
+    kdf: KdfChoice,
+
+    /// Duration for each KDF in milliseconds
+    #[arg(short, long, default_value_t = 1000)]
+    msecs: u64,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum KdfChoice {
+    Aes,
+    Argon2,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let duration = Duration::from_millis(args.msecs);
+
+    match args.kdf {
+        KdfChoice::Aes => {
+            let kdf = AesKdf {
+                seed: vec![0; 32],
+                rounds: 100_000,
+            };
+            println!("Benchmarking AES KDF for {} ms...", args.msecs);
+            let rounds = kdf.benchmark(duration)?;
+            println!("AES KDF: {} rounds in {} ms", rounds, args.msecs);
+        }
+        KdfChoice::Argon2 => {
+            let kdf = Argon2Kdf {
+                salt: vec![0; 32],
+                parallelism: 1,
+                memory: 1024 * 1024, // 1 MiB
+                iterations: 1,
+                variant: argon2::Variant::Argon2id,
+                version: argon2::Version::Version13,
+            };
+            println!(
+                "Benchmarking Argon2id KDF with {} KiB memory and parallelism {} for {} ms...",
+                kdf.memory / 1024,
+                kdf.parallelism,
+                args.msecs
+            );
+            let iterations = kdf.benchmark(duration)?;
+            println!("Argon2id KDF: {} iterations in {} ms", iterations, args.msecs);
+        }
+    }
+
+    Ok(())
+}

--- a/src/crypt/kdf.rs
+++ b/src/crypt/kdf.rs
@@ -1,4 +1,5 @@
 use std::convert::TryInto;
+use std::time::Duration;
 
 use aes::Aes256;
 use cipher::{BlockCipherEncrypt, KeyInit};
@@ -7,15 +8,23 @@ use sha2::{Digest, Sha256};
 
 use super::CryptographyError;
 
-pub(crate) trait Kdf {
+/// Trait for Key Derivation Functions
+pub trait Kdf {
+    /// Transform a composite key into a final key
     fn transform_key(
         &self,
         composite_key: &GenericArray<u8, U32>,
     ) -> Result<GenericArray<u8, U32>, CryptographyError>;
+
+    /// Benchmark the KDF for a given duration
+    fn benchmark(&self, duration: Duration) -> Result<usize, CryptographyError>;
 }
 
+/// AES-based Key Derivation Function
 pub struct AesKdf {
+    /// Seed for the AES KDF
     pub seed: Vec<u8>,
+    /// Number of rounds to perform
     pub rounds: u64,
 }
 
@@ -49,14 +58,56 @@ impl Kdf for AesKdf {
 
         Ok(digest.finalize())
     }
+
+    fn benchmark(&self, duration: Duration) -> Result<usize, CryptographyError> {
+        let composite_key: GenericArray<u8, U32> = [0; 32].into();
+        let trials = 3;
+        let rounds_per_trial = 1_000_000;
+
+        let seed_arr: GenericArray<u8, U32> = self
+            .seed
+            .as_slice()
+            .try_into()
+            .map_err(|_| CryptographyError::InvalidLength(cipher::InvalidLength))?;
+        let cipher = Aes256::new(&seed_arr);
+        let mut block1: GenericArray<u8, _> = composite_key[..16]
+            .try_into()
+            .map_err(|_| CryptographyError::InvalidLength(cipher::InvalidLength))?;
+        let mut block2: GenericArray<u8, _> = composite_key[16..]
+            .try_into()
+            .map_err(|_| CryptographyError::InvalidLength(cipher::InvalidLength))?;
+
+        let start_time = std::time::Instant::now();
+        for _ in 0..trials {
+            for _ in 0..rounds_per_trial {
+                cipher.encrypt_block(&mut block1);
+                cipher.encrypt_block(&mut block2);
+            }
+        }
+        let elapsed = start_time.elapsed();
+
+        if elapsed.is_zero() {
+            return Err(CryptographyError::BenchmarkError);
+        }
+
+        let total_rounds = rounds_per_trial * trials;
+        Ok((total_rounds as u128 * duration.as_nanos() / elapsed.as_nanos()) as usize)
+    }
 }
 
+/// Argon2-based Key Derivation Function
 pub struct Argon2Kdf {
+    /// Memory cost in bytes
     pub memory: u64,
+    /// Salt for the Argon2 KDF
     pub salt: Vec<u8>,
+    /// Number of iterations
     pub iterations: u64,
+    /// Degree of parallelism
     pub parallelism: u32,
+    /// Argon2 version
     pub version: argon2::Version,
+    /// Argon2 variant
     pub variant: argon2::Variant,
 }
 
@@ -89,5 +140,35 @@ impl Kdf for Argon2Kdf {
         key.as_slice()
             .try_into()
             .map_err(|_| CryptographyError::InvalidLength(cipher::InvalidLength))
+    }
+
+    fn benchmark(&self, duration: Duration) -> Result<usize, CryptographyError> {
+        let composite_key: GenericArray<u8, U32> = [0; 32].into();
+
+        let config = argon2::Config {
+            thread_mode: if cfg!(target_arch = "wasm32") {
+                argon2::ThreadMode::Sequential
+            } else {
+                argon2::ThreadMode::Parallel
+            },
+            ad: &[],
+            hash_length: 32,
+            lanes: self.parallelism,
+            mem_cost: (self.memory / 1024) as u32,
+            secret: &[],
+            time_cost: 1, // benchmark for one iteration
+            variant: self.variant,
+            version: self.version,
+        };
+
+        let start_time = std::time::Instant::now();
+        let _ = argon2::hash_raw(&composite_key, &self.salt, &config)?;
+        let elapsed = start_time.elapsed();
+
+        if elapsed.is_zero() {
+            return Err(CryptographyError::BenchmarkError);
+        }
+
+        Ok((duration.as_nanos() / elapsed.as_nanos()) as usize)
     }
 }

--- a/src/crypt/mod.rs
+++ b/src/crypt/mod.rs
@@ -12,8 +12,10 @@ use sha1::Sha1;
 use sha2::{Digest, Sha256, Sha512};
 use thiserror::Error;
 
+/// Implementation of cryptographic primitives used in the KDBX format.
 pub(crate) mod ciphers;
-pub(crate) mod kdf;
+/// Key Derivation Functions
+pub mod kdf;
 
 pub(crate) fn calculate_hmac(elements: &[&[u8]], key: &[u8]) -> Result<GenericArray<u8, U32>, InvalidLength> {
     type HmacSha256 = Hmac<Sha256>;
@@ -78,4 +80,8 @@ pub enum CryptographyError {
     /// Errors related to the Argon2 key derivation function
     #[error(transparent)]
     Argon2(#[from] argon2::Error),
+
+    /// The benchmark could not be completed
+    #[error("Benchmark failed")]
+    BenchmarkError,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
 
 mod compression;
 pub mod config;
-pub(crate) mod crypt;
+/// Cryptographic functions and Key Derivation Functions
+pub mod crypt;
 pub mod db;
 pub mod error;
 pub(crate) mod format;


### PR DESCRIPTION
The implementation for both KDF algos is similar to that of keepassxc. The only difference is that we're returning an error if we can't compute a reliable benchmark instead of returning 1, which I'm afraid could lead to users configuring their DBs with very weak KDF settings.