### PR TITLE
chore: use nix flake for cargo hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,11 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-hack
+      - uses: DeterminateSystems/nix-installer-action@v11
       - name: typecheck the tests
-        run: cargo check --tests
+        run: nix develop --command cargo check --tests
       - name: run cargo check on all feature combinations
-        run: cargo hack check --feature-powerset --no-dev-deps
+        run: nix develop --command cargo hack check --feature-powerset --no-dev-deps
 
   build-windows:
     name: Build the project (Windows)

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
               rust-analyzer
               cargo-tarpaulin
               cargo-msrv
+              cargo-hack
             ];
           };
         }


### PR DESCRIPTION
This continues the migration of our CI workflows to using the nix flake, which allows running CI jobs locally, amongst other benefits.

At some point all the jobs will be installing the same nix flake before running their checks, so I'll have to think of a way to cache it first for all the jobs to then use.