### PR TITLE
docs: create proper code examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,3 +132,7 @@ required-features = ["utilities", "save_kdbx4", "challenge_response"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
+
+[[example]]
+name = "save_database"
+required-features = ["save_kdbx4"]

--- a/README.md
+++ b/README.md
@@ -10,99 +10,10 @@
 Rust KeePass database file parser for KDB, KDBX3 and KDBX4, with experimental support for KDBX4 writing.
 
 ## Usage
-<details>
-<summary>
 
-### Open a database
-</summary>
-
-```rust
-use keepass::{
-    db::NodeRef,
-    Database,
-    DatabaseKey,
-    error::DatabaseOpenError
-};
-use std::fs::File;
-
-fn main() -> Result<(), DatabaseOpenError> {
-    // Open KeePass database using a password (keyfile is also supported)
-    let mut file = File::open("tests/resources/test_db_with_password.kdbx")?;
-    let key = DatabaseKey::new().with_password("demopass");
-    let db = Database::open(&mut file, key)?;
-
-    // Iterate over all `Group`s and `Entry`s
-    for node in &db.root {
-        match node {
-            NodeRef::Group(g) => {
-                println!("Saw group '{0}'", g.name);
-            },
-            NodeRef::Entry(e) => {
-                let title = e.get_title().unwrap_or("(no title)");
-                let user = e.get_username().unwrap_or("(no username)");
-                let pass = e.get_password().unwrap_or("(no password)");
-                println!("Entry '{0}': '{1}' : '{2}'", title, user, pass);
-            }
-        }
-    }
-
-    Ok(())
-}
-```
-</details>
-
-<details>
-<summary>
-
-### Save a KDBX4 database (EXPERIMENTAL)
-
-</summary>
-
-**IMPORTANT:** The inner XML data structure will be re-written from scratch from the internal object representation of this crate, so any field that is not parsed by the library will be lost in the written output file! Please make sure to back up your database before trying this feature.
-
-You can enable the experimental support for saving KDBX4 databases using the `save_kdbx4` feature.
-
-```rust
-use keepass::{
-    db::{Database, Entry, Group, Node, NodeRef, Value},
-    DatabaseKey,
-};
-use std::fs::File;
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut db = Database::new(Default::default());
-
-    db.meta.database_name = Some("Demo database".to_string());
-
-    let mut group = Group::new("Demo group");
-
-    let mut entry = Entry::new();
-    entry.fields.insert("Title".to_string(), Value::Unprotected("Demo entry".to_string()));
-    entry.fields.insert("UserName".to_string(), Value::Unprotected("jdoe".to_string()));
-    entry.fields.insert("Password".to_string(), Value::Protected("hunter2".as_bytes().into()));
-
-    group.add_child(entry);
-
-    db.root.add_child(group);
-
-    #[cfg(feature = "save_kdbx4")]
-    db.save(
-        &mut File::create("demo.kdbx")?,
-        DatabaseKey::new().with_password("demopass"),
-    )?;
-
-    Ok(())
-}
-```
-
-</details>
-
-<details>
-<summary>
+Examples are available in the [`examples`](./examples) directory of this repository.
 
 ### Use developer tools
-
-</summary>
 
 This crate contains several command line tools that can be enabled with the `utilities` feature flag.
 See the `[[bin]]` sections in [Cargo.toml](Cargo.toml) for a complete list.
@@ -112,8 +23,6 @@ An example command line for running the `kp-dump-xml` command would be:
 ```bash
 cargo run --release --features "utilities" --bin kp-dump-xml -- path/to/database.kdbx
 ```
-
-</details>
 
 
 ## Installation

--- a/examples/open_database.rs
+++ b/examples/open_database.rs
@@ -1,0 +1,26 @@
+use keepass::{db::NodeRef, error::DatabaseOpenError, Database, DatabaseKey};
+use std::fs::File;
+
+fn main() -> Result<(), DatabaseOpenError> {
+    // Open KeePass database using a password (keyfile is also supported)
+    let mut file = File::open("tests/resources/test_db_with_password.kdbx")?;
+    let key = DatabaseKey::new().with_password("demopass");
+    let db = Database::open(&mut file, key)?;
+
+    // Iterate over all `Group`s and `Entry`s
+    for node in &db.root {
+        match node {
+            NodeRef::Group(g) => {
+                println!("Saw group '{0}'", g.name);
+            }
+            NodeRef::Entry(e) => {
+                let title = e.get_title().unwrap_or("(no title)");
+                let user = e.get_username().unwrap_or("(no username)");
+                let pass = e.get_password().unwrap_or("(no password)");
+                println!("Entry '{0}': '{1}' : '{2}'", title, user, pass);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/examples/save_database.rs
+++ b/examples/save_database.rs
@@ -1,0 +1,37 @@
+use keepass::{
+    db::{Database, Entry, Group, Value},
+    DatabaseKey,
+};
+use std::fs::File;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut db = Database::new(Default::default());
+
+    db.meta.database_name = Some("Demo database".to_string());
+
+    let mut group = Group::new("Demo group");
+
+    let mut entry = Entry::new();
+    entry
+        .fields
+        .insert("Title".to_string(), Value::Unprotected("Demo entry".to_string()));
+    entry
+        .fields
+        .insert("UserName".to_string(), Value::Unprotected("jdoe".to_string()));
+    entry.fields.insert(
+        "Password".to_string(),
+        Value::Protected("hunter2".as_bytes().into()),
+    );
+
+    group.add_child(entry);
+
+    db.root.add_child(group);
+
+    #[cfg(feature = "save_kdbx4")]
+    db.save(
+        &mut File::create("demo.kdbx")?,
+        DatabaseKey::new().with_password("demopass"),
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
This will unclutter the README and make sure that the examples compile and are free of compilation warnings or code formatting issues.