### PR TITLE
ci: do not fail on deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ name: CI on Pull Requests
 on:
   pull_request:
 
+env:
+  RUSTFLAGS: -D warnings -A deprecated
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -23,8 +26,6 @@ jobs:
   doc:
     name: Build Doc
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,8 +40,6 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v11
@@ -52,8 +51,6 @@ jobs:
   build-windows:
     name: Build the project (Windows)
     runs-on: windows-latest
-    env:
-      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -88,8 +85,6 @@ jobs:
           #   name: armv8
           #   with_cross_compilation: false
 
-    env:
-      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Excerpt of the warnings we're getting:
```
warning: use of deprecated struct `cipher::generic_array::GenericArray`: please upgrade to generic-array 1.x
 --> src/crypt/mod.rs:5:5
  |
5 |     GenericArray,
  |     ^^^^^^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default

warning: use of deprecated struct `cipher::generic_array::GenericArray`: please upgrade to generic-array 1.x
  --> src/crypt/mod.rs:21:13
   |
21 | ) -> Result<GenericArray<u8, U32>, CryptographyError> {
   |             ^^^^^^^^^^^^

warning: use of deprecated struct `cipher::generic_array::GenericArray`: please upgrade to generic-array 1.x
  --> src/crypt/mod.rs:49:62
   |
49 | pub(crate) fn calculate_sha256(elements: &[&[u8]]) -> Result<GenericArray<u8, U32>, CryptographyError> {
   |                                                              ^^^^^^^^^^^^

warning: use of deprecated struct `cipher::generic_array::GenericArray`: please upgrade to generic-array 1.x
  --> src/crypt/mod.rs:59:62
   |
59 | pub(crate) fn calculate_sha512(elements: &[&[u8]]) -> Result<GenericArray<u8, U64>, CryptographyError> {
```

I think we can relax the rule to allow deprecation warnings since we are bound to see those from time to time, and an immediate fix might not be available.