### PR TITLE
Support wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ base32 = { version = "0.5", optional = true }
 [dev-dependencies]
 rustfmt = "0.10"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
+
 [[bin]]
 # parse a KeePass database and output as a JSON document
 name = "kp-dump-json"

--- a/src/crypt/kdf.rs
+++ b/src/crypt/kdf.rs
@@ -55,8 +55,15 @@ impl Kdf for Argon2Kdf {
         &self,
         composite_key: &GenericArray<u8, U32>,
     ) -> Result<GenericArray<u8, U32>, CryptographyError> {
+        // Disable Argon2 multithreading on wasm32 targets to avoid panics on platforms without thread support.
+        let thread_mode = if cfg!(target_arch = "wasm32") {
+            argon2::ThreadMode::Sequential
+        } else {
+            argon2::ThreadMode::Parallel
+        };
+
         let config = argon2::Config {
-            thread_mode: argon2::ThreadMode::Parallel,
+            thread_mode,
             ad: &[],
             hash_length: 32,
             lanes: self.parallelism,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -585,6 +585,18 @@ pub const CREATION_TIME_TAG_NAME: &str = "CreationTime";
 pub const LAST_ACCESS_TIME_TAG_NAME: &str = "LastAccessTime";
 pub const LOCATION_CHANGED_TAG_NAME: &str = "LocationChanged";
 
+#[cfg(target_arch = "wasm32")]
+fn now_timestamp() -> i64 {
+    // Use JS Date.now() to get the current time in milliseconds, then convert it to seconds.
+    let millis = js_sys::Date::now();
+    (millis / 1000.0) as i64
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn now_timestamp() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
 impl Times {
     fn get(&self, key: &str) -> Option<&NaiveDateTime> {
         self.times.get(key)
@@ -634,7 +646,7 @@ impl Times {
     // Returns the current time, without the nanoseconds since
     // the last leap second.
     pub fn now() -> NaiveDateTime {
-        let now = chrono::Utc::now().timestamp();
+        let now = now_timestamp();
         chrono::DateTime::from_timestamp(now, 0).unwrap().naive_utc()
     }
 


### PR DESCRIPTION
## Summary

This PR adds improved `wasm32` support to `keepass-rs`, making it safer and more reliable to use in WebAssembly environments (e.g. browsers) without affecting existing native targets.

## Motivation

- When running on `wasm32`, some assumptions about time and threading do not hold (no OS clock, no native threads in many environments).
- `keepass-rs` is used in web contexts where deterministic, panic‑free behavior is important, especially around Argon2 key derivation and timestamp handling.
- The goal is to provide a minimal, targeted set of changes that make the crate “just work” on `wasm32` while keeping the native behavior unchanged.

## Implementation details

- **Target-specific time source for `Times::now`**
  - Introduce a small helper, `now_timestamp()`, that is specialized per target:
    - On `wasm32`, use `js_sys::Date::now()` to obtain the current time from the JavaScript host and convert it to a Unix timestamp in seconds.
    - On non-`wasm32` targets, keep using `chrono::Utc::now().timestamp()` as before.
  - `Times::now()` and the associated timestamp helpers are updated to go through this abstraction so that all time handling works consistently on both native and `wasm32`.

- **Safe Argon2 configuration on `wasm32`**
  - For the Argon2-based KDF, configure the thread mode based on the compilation target:
    - On `wasm32`, force `argon2::ThreadMode::Sequential` to avoid panics on platforms that do not provide WebAssembly thread support.
    - On other targets, keep using `argon2::ThreadMode::Parallel` to preserve existing performance characteristics.
  - This keeps the KDF behavior functionally equivalent while avoiding runtime failures in browser environments.

### Limitations

- **Only single-threaded mode is supported on `wasm32`**

## Compatibility

- No public API or feature flags were changed.
- Native builds (`x86_64-unknown-linux-*`, `x86_64-pc-windows-*`, etc.) should behave exactly as before.
- The WebAssembly-specific behavior is only enabled when compiling for `wasm32`, and is implemented via `cfg` guards.
