### PR TITLE
feat: basic wasm CI/CD

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
+
 [build]
 # Enable CPU-specific optimizations.
 # This can greatly improve performance for AES key derivation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,3 +156,31 @@ jobs:
       - name: Generate code coverage
         run: |
           nix develop --command cargo tarpaulin --verbose --timeout 120
+
+  wasm32-tests:
+    name: WASM32 Tests (Node)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+      - name: Run wasm tests (Node)
+        run: wasm-pack test --node
+
+  wasm32-check:
+    name: WASM32 Compile Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Cargo check keepass lib for wasm32 (no default features)
+        run: cargo check --target wasm32-unknown-unknown --no-default-features --lib -p keepass

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ cbc = "0.1"
 
 challenge_response = { version = "0.5", optional = true, default-features = false, features = ["nusb"] }
 
-uuid = { version = "1.2", features = ["v4", "serde"] }
+uuid = { version = "1.18.1", features = ["v4", "serde"] }
 hex = { version = "0.4" }
 getrandom = { version = "0.3", features = ["std"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
@@ -80,11 +80,22 @@ totp-lite = { version = "2.0", optional = true }
 url = { version = "2.2", optional = true }
 base32 = { version = "0.5", optional = true }
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# rustfmt is only needed for native targets; compiling it (and its syntex_*) for
+# wasm32 causes build failures, so we keep it as a dev-dependency but exclude it
+# on wasm.
 rustfmt = "0.10"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
+# For wasm32-unknown-unknown, use the JS backend of getrandom. This mirrors the
+# configuration used in the database crate and ensures that random bytes work
+# correctly in WebAssembly environments.
+getrandom = { version = "0.3.4", features = ["wasm_js"] }
+uuid = { version = "1.18.1", features = ["js"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [[bin]]
 # parse a KeePass database and output as a JSON document

--- a/tests/wasm_open_database.rs
+++ b/tests/wasm_open_database.rs
@@ -1,0 +1,20 @@
+#![cfg(target_arch = "wasm32")]
+
+use keepass::{db::Database, DatabaseKey};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+/// Ensure that opening an Argon2-encrypted KDBX4 database does not panic
+/// when running inside a wasm32 runtime (regression test for the "support wasm" change).
+#[wasm_bindgen_test]
+fn open_kdbx4_argon2_in_wasm_does_not_panic() {
+    // This database uses Argon2; historically, multithreaded Argon2 could
+    // cause panics on wasm targets without thread support. This test ensures
+    // that the wasm configuration works end-to-end.
+    const DB_BYTES: &[u8] = include_bytes!("resources/test_db_kdbx4_with_password_argon2.kdbx");
+
+    let db = Database::parse(DB_BYTES, DatabaseKey::new().with_password("demopass"))
+        .expect("database should open successfully in wasm without panicking");
+
+    // A small sanity check to confirm that parsing actually succeeded.
+    assert_eq!(db.root.name, "Root");
+}


### PR DESCRIPTION
## Title

Add basic wasm32 CI job for keepass-rs

## Description

This PR adds a minimal CI job to ensure `keepass-rs` builds and runs tests for the `wasm32-unknown-unknown` target:

- **Wasm test job in CI**
  - New `wasm32-tests` job in `.github/workflows/ci.yml`.
  - Runs on `ubuntu-latest` with the stable Rust toolchain.
  - Installs the `wasm32-unknown-unknown` target and `wasm-pack`.
  - Executes `wasm-pack test --node` to run the wasm test suite.

- **Basic wasm runtime test**
  - Adds `tests/wasm_open_database.rs` using `wasm-bindgen-test`.
  - The test opens an Argon2-encrypted KDBX4 database in a wasm runtime and asserts it parses successfully.
