### PR TITLE
ci: switch to trusted publishing

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -64,9 +64,8 @@ jobs:
       - test
       - coverage
     permissions:
-      # This permission is required in order to push the new
-      # tag to the repository.
-      contents: write
+      contents: write # required to push the new git tag
+      id-token: write # required for trusted publishing
     runs-on: ubuntu-latest
     env:
       next-version: ${{ needs.get-next-version.outputs.version }}
@@ -87,11 +86,12 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
 
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+        id: auth
+
       - name: Publish new Cargo version
         env:
-          # This token needs to be created with the publish-update scope.
-          # The other scopes are not necessary.
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           nix develop --command cargo publish --allow-dirty
 


### PR DESCRIPTION
I have already configured the `merge.yml` workflow as a trusted publisher in crates.io. I will tick the `Require trusted publishing` option once we have merged this and validated that the new authentication scheme works, at which point we can also delete the token from the GH secrets. 

<img width="947" height="299" alt="image" src="https://github.com/user-attachments/assets/60e39853-cb6b-4d89-8b7a-15df4422dbe9" />
