### PR TITLE
Fix DeletedObject deletion_time field name

### DIFF
--- a/src/format/xml_db/mod.rs
+++ b/src/format/xml_db/mod.rs
@@ -210,6 +210,7 @@ pub struct DeletedObjects {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 pub struct DeletedObject {
     #[serde(rename = "UUID")]
     uuid: UUID,


### PR DESCRIPTION
This bash script demonstrates how DeletedObjects in a database generated by `keepassxc-cli` are lost when round-tripping the database through keepass-rs:

```bash
keyfile="/tmp/key"
before_db="/tmp/before.kdbx"
after_db="/tmp/after.kdbx"

head -c 32 /dev/urandom > "$keyfile"

               # Create database
               keepassxc-cli db-create -q   --set-key-file "$keyfile" "$before_db"
               # Add an entry to the database
               keepassxc-cli add       -q --no-password -k "$keyfile" "$before_db" -u demo TrashMe
               # Delete the entry from the database (moving it to the recycle bin)
printf 'y\n' | keepassxc-cli rm        -q --no-password -k "$keyfile" "$before_db" TrashMe
               # Permanently delete the entry from the recycle bin
printf 'y\n' | keepassxc-cli rm        -q --no-password -k "$keyfile" "$before_db" 'Recycle Bin/TrashMe'

echo "=== BEFORE ==="
# Print the DeletedObjects in the database
keepassxc-cli export -q -k "$keyfile" --no-password -f xml "$before_db" | grep -C 5 'DeletedObjects'

# Round-trip
cargo run --quiet --features 'utilities save_kdbx4' --bin \
    kp-rewrite -- -n -k "$keyfile" "$before_db" "$after_db"

echo "=== AFTER ==="
keepassxc-cli export -q -k "$keyfile" --no-password -f xml "$after_db" | grep -C 5 'DeletedObjects'
```

Output:
```diff
nulldev@agent-oryn:/tmp/keepass-rs$ bash repro.sh 
=== BEFORE ===
                                <EnableAutoType>false</EnableAutoType>
                                <EnableSearching>false</EnableSearching>
                                <LastTopVisibleEntry>AAAAAAAAAAAAAAAAAAAAAA==</LastTopVisibleEntry>
                        </Group>
                </Group>
                <DeletedObjects>
                        <DeletedObject>
                                <UUID>xgnz+ymeQ8SibmYts1ejEQ==</UUID>
                                <DeletionTime>IoxJ4Q4AAAA=</DeletionTime>
                        </DeletedObject>
                </DeletedObjects>
        </Root>
</KeePassFile>
=== AFTER ===
KdbxXmlReader::skipCurrentElement: skip element "DefaultUsername"
KdbxXmlReader::skipCurrentElement: skip element "DefaultUsernameChanged"
KdbxXmlReader::skipCurrentElement: skip element "ProtectUsername"
KdbxXmlReader::skipCurrentElement: skip element "deletion_time"
nulldev@agent-oryn:/tmp/keepass-rs$
```

This PR ensures that the deletion time is properly deserialized on DeletedObjects, which allows them to be round-tripped properly.