### PR TITLE
refactor!: mark several public types non_exhaustive

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,7 @@ const CHA_CHA_20: u32 = 3;
 /// Configuration of how a database should be stored
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+#[non_exhaustive]
 pub struct DatabaseConfig {
     /// Version of the outer database file
     pub version: DatabaseVersion,
@@ -75,6 +76,7 @@ impl Default for DatabaseConfig {
 /// Choices for outer encryption
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+#[non_exhaustive]
 pub enum OuterCipherConfig {
     AES256,
     Twofish,
@@ -130,6 +132,7 @@ impl TryFrom<&[u8]> for OuterCipherConfig {
 
 /// Errors with the configuration of the outer encryption
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum OuterCipherConfigError {
     #[error(transparent)]
     Cryptography(#[from] CryptographyError),
@@ -141,6 +144,7 @@ pub enum OuterCipherConfigError {
 /// Choices for encrypting protected values inside of databases
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+#[non_exhaustive]
 pub enum InnerCipherConfig {
     Plain,
     Salsa20,
@@ -193,6 +197,7 @@ impl TryFrom<u32> for InnerCipherConfig {
 
 /// Errors with the configuration of the inner encryption
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum InnerCipherConfigError {
     #[error(transparent)]
     Cryptography(#[from] CryptographyError),
@@ -216,6 +221,7 @@ const KDF_ROUNDS: &str = "R";
 /// Choices for Key Derivation Functions (KDFs)
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+#[non_exhaustive]
 pub enum KdfConfig {
     /// Derive keys with repeated AES encryption
     Aes { rounds: u64 },
@@ -415,6 +421,7 @@ impl TryFrom<VariantDictionary> for (KdfConfig, Vec<u8>) {
 
 /// Errors with the configuration of the Key Derivation Function
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum KdfConfigError {
     #[error("Invalid KDF version: {}", version)]
     InvalidKDFVersion { version: u32 },
@@ -429,6 +436,7 @@ pub enum KdfConfigError {
 /// Choices of compression algorithm
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+#[non_exhaustive]
 pub enum CompressionConfig {
     None,
     GZip,
@@ -465,6 +473,7 @@ impl TryFrom<u32> for CompressionConfig {
 
 /// Errors with the configuration of the compression algorithm
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum CompressionConfigError {
     /// The identifier for the compression algorithm specified in the database is invalid
     #[error("Invalid compression algorithm: {}", cid)]

--- a/src/crypt/mod.rs
+++ b/src/crypt/mod.rs
@@ -64,6 +64,7 @@ pub(crate) fn calculate_sha512(elements: &[&[u8]]) -> GenericArray<u8, U64> {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum CryptographyError {
     #[error(transparent)]
     InvalidLength(#[from] InvalidLength),

--- a/src/db/merge.rs
+++ b/src/db/merge.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum MergeEventType {
     Created,
     Deleted,
@@ -17,6 +18,7 @@ pub enum MergeEventType {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum MergeEventTarget {
     Entry(EntryId),
     Group(GroupId),
@@ -29,8 +31,8 @@ pub struct MergeEvent {
 }
 
 /// Errors while merge two databases
-#[derive(Error)]
-#[derive(Debug)]
+#[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum MergeError {
     #[error("Entries with UUID {0} have the same modification time but have diverged.")]
     EntryModificationTimeNotUpdated(EntryId),

--- a/src/db/open.rs
+++ b/src/db/open.rs
@@ -60,6 +60,7 @@ impl Database {
 
 /// Errors that can occur when opening a database
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DatabaseOpenError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -84,6 +85,7 @@ pub enum DatabaseOpenError {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DatabaseFormatError {
     #[error(transparent)]
     Kdb(#[from] crate::format::kdb::KdbOpenError),

--- a/src/db/otp.rs
+++ b/src/db/otp.rs
@@ -12,6 +12,7 @@ const DEFAULT_DIGITS: u32 = 8;
 
 /// Choices of hash algorithm for TOTP
 #[derive(Debug, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
+#[non_exhaustive]
 pub enum TOTPAlgorithm {
     Sha1,
     Sha256,
@@ -64,6 +65,7 @@ impl std::fmt::Display for OTPCode {
 
 /// Errors while processing a TOTP specification
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum TOTPError {
     #[error(transparent)]
     UrlFormat(#[from] url::ParseError),

--- a/src/db/save.rs
+++ b/src/db/save.rs
@@ -20,6 +20,7 @@ impl Database {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DatabaseSaveError {
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/src/db/types/group.rs
+++ b/src/db/types/group.rs
@@ -545,6 +545,7 @@ impl GroupMut<'_> {
 
 /// Errors that can occur when moving a group to a new parent.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum MoveGroupError {
     /// The root group cannot be moved
     #[error("Cannot move the root group")]

--- a/src/format/hmac_block_stream.rs
+++ b/src/format/hmac_block_stream.rs
@@ -106,6 +106,7 @@ pub(crate) fn get_hmac_block_key(block_index: u64, key: &GenericArray<u8, U64>) 
 
 /// Errors reading from the HMAC block stream
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum BlockStreamError {
     #[error("Block hash mismatch for block {}", block_index)]
     BlockHashMismatch { block_index: u64 },

--- a/src/format/kdb.rs
+++ b/src/format/kdb.rs
@@ -473,6 +473,7 @@ pub(crate) fn parse_kdb(data: &[u8], db_key: &DatabaseKey) -> Result<Database, D
 
 /// Errors that can occur when opening a KeePass 1 database
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum KdbOpenError {
     #[error("Field of type {field_type} has invalid length {field_size}, expected {expected_field_size}")]
     InvalidFieldLength {

--- a/src/format/kdbx3.rs
+++ b/src/format/kdbx3.rs
@@ -147,6 +147,7 @@ fn parse_outer_header(data: &[u8]) -> Result<KDBX3Header, Kdbx3OuterHeaderError>
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Kdbx3OuterHeaderError {
     #[error(transparent)]
     InnerCipher(#[from] crate::config::InnerCipherConfigError),
@@ -278,6 +279,7 @@ pub(crate) fn decrypt_kdbx3(
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Kdbx3OpenError {
     #[error(transparent)]
     OuterHeader(#[from] Kdbx3OuterHeaderError),

--- a/src/format/kdbx4/parse.rs
+++ b/src/format/kdbx4/parse.rs
@@ -247,6 +247,7 @@ fn parse_outer_header(data: &[u8]) -> Result<(KDBX4OuterHeader, usize), Kdbx4Out
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Kdbx4OuterHeaderError {
     #[error("Unexpected end of file while parsing outer header")]
     UnexpectedEof,
@@ -336,6 +337,7 @@ fn parse_inner_header(
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Kdbx4InnerHeaderError {
     #[error(transparent)]
     InnerCipherConfig(#[from] crate::config::InnerCipherConfigError),
@@ -348,6 +350,7 @@ pub enum Kdbx4InnerHeaderError {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Kdbx4OpenError {
     #[error(transparent)]
     Xml(#[from] crate::format::xml_db::ParseXmlError),

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -109,6 +109,7 @@ impl std::fmt::Display for DatabaseVersion {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DatabaseVersionParseError {
     #[error("Unexpected end of file while reading database version")]
     UnexpectedEof,

--- a/src/format/variant_dictionary.rs
+++ b/src/format/variant_dictionary.rs
@@ -164,6 +164,7 @@ impl VariantDictionary {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+#[non_exhaustive]
 pub enum VariantDictionaryValue {
     UInt32(u32),
     UInt64(u64),
@@ -281,6 +282,7 @@ impl<'a> From<&'a VariantDictionaryValue> for Option<&'a Vec<u8>> {
 
 /// Errors while parsing a VariantDictionary
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum VariantDictionaryError {
     #[error("Invalid variant dictionary version: {}", version)]
     InvalidVersion { version: u16 },

--- a/src/format/xml_db/entry.rs
+++ b/src/format/xml_db/entry.rs
@@ -213,6 +213,7 @@ impl Entry {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum UnprotectError {
     #[error("Error base64 decoding protected value: {0}")]
     Base64(#[from] base64::DecodeError),

--- a/src/format/xml_db/mod.rs
+++ b/src/format/xml_db/mod.rs
@@ -39,6 +39,7 @@ pub fn parse_xml(
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ParseXmlError {
     #[error("Error parsing XML inside KDBX: {0}")]
     Xml(#[from] quick_xml::DeError),

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -85,6 +85,7 @@ fn parse_xml_keyfile(xml: &[u8]) -> Result<KeyElement, ParseXmlKeyFileError> {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ParseXmlKeyFileError {
     #[error("The XML keyfile is missing a key data element")]
     EmptyKey,
@@ -213,6 +214,7 @@ impl DatabaseKey {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DatabaseKeyError {
     #[error("The key contains no components")]
     EmptyKey,

--- a/src/key/yubikey.rs
+++ b/src/key/yubikey.rs
@@ -10,6 +10,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::key::KeyElement;
 
 #[derive(Debug, Clone, PartialEq, Zeroize, ZeroizeOnDrop)]
+#[non_exhaustive]
 pub enum ChallengeResponseKey {
     LocalChallenge(String),
     YubikeyChallenge(Yubikey, String),
@@ -90,6 +91,7 @@ impl ChallengeResponseKey {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ChallengeResponseKeyError {
     #[error("No challenge-respone keys are connected to the system.")]
     NoKeys,


### PR DESCRIPTION
To allow future changes to the API without breaking backwards compatibility, mark several public types as non_exhaustive to prevent users from exhaustively matching against these types.

BREAKING CHANGE: destructuring matches on marked types will fail.