### PR TITLE
Narrow wasm32 cfg gate so wasi targets don't pull in js-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,11 @@ base32 = { version = "0.5", optional = true }
 # on wasm.
 rustfmt = "0.10"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+# Browser-only deps: wasm32-unknown-unknown is the canonical browser target.
+# wasi-flavoured wasm32 targets (wasm32-wasip1, wasm32-wasip2) use their own
+# backends in getrandom/uuid and cannot resolve js-sys' wasm-bindgen
+# placeholder imports, so they must NOT pull these in.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys = "0.3"
 # For wasm32-unknown-unknown, use the JS backend of getrandom. This mirrors the
 # configuration used in the database crate and ensures that random bytes work
@@ -95,7 +99,7 @@ js-sys = "0.3"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 uuid = { version = "1.18.1", features = ["js"] }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [[bin]]

--- a/src/db/types/times.rs
+++ b/src/db/types/times.rs
@@ -32,12 +32,19 @@ pub struct Times {
     pub usage_count: Option<usize>,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+// On non-browser targets — including wasm32-wasip1 and wasm32-wasip2 —
+// chrono::Utc::now() works (wasi clocks via WASI 0.1+ are supported by
+// chrono's `clock` feature).  The `js_sys::Date::now()` path is only
+// usable in true browser contexts (target_arch = "wasm32" with target_os
+// = "unknown"), where wasm-bindgen post-processes the binary to resolve
+// the placeholder imports.  Targeting "wasm32" alone unintentionally
+// catches WASI builds and breaks linking.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn now_timestamp() -> i64 {
     chrono::Utc::now().timestamp()
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn now_timestamp() -> i64 {
     // Use JS Date.now() to get the current time in milliseconds, then convert it to seconds.
     let millis = js_sys::Date::now();


### PR DESCRIPTION
## Problem

Two `cfg(target_arch = "wasm32")` gates currently match **all** wasm32 targets — both `wasm32-unknown-unknown` (browsers) **and** the wasi-flavoured `wasm32-wasip1` / `wasm32-wasip2` targets:

1. `src/db/types/times.rs` — switches `Times::now()` from `chrono::Utc::now()` to `js_sys::Date::now()`.
2. `Cargo.toml` — adds `js-sys`, `getrandom["wasm_js"]`, and `uuid["js"]` as wasm32 deps.

On wasi targets the wasm-bindgen post-processing step never runs, so any code that pulls keepass-rs into a wasi guest fails to instantiate with:

```
unknown import: `__wbindgen_placeholder__::__wbindgen_describe` has not been defined
```

This blocks using keepass-rs from inside an Extism / wasmtime-hosted wasi guest, even when nothing in the consumer ever calls `Times::now()` — wasm-bindgen describe symbols are emitted as imports regardless of whether the wrapping function is reachable, and LTO can't strip them.

## Fix

Narrow the cfg to `cfg(all(target_arch = "wasm32", target_os = "unknown"))` so it targets the canonical browser tuple only. wasi targets fall through to the native path:

- `chrono::Utc::now()` works on wasi via the existing `clock` feature
- `getrandom` uses its built-in wasi backend (no `wasm_js` feature needed)
- `uuid` uses its default — wasi-compatible without the `js` feature

No behavioural change for browser consumers.

## Verification

- All existing tests pass (`cargo test`): 57 passing across the suite.
- Builds cleanly on `wasm32-wasip1` after this patch.
- Built and consumed successfully in a downstream Extism guest plugin (rosec-keepassxc-file) that reads `.kdbx` files via host-provided file imports — `Database::open`, entry walk, and field decryption all work.

## Notes

The version field in `Cargo.toml` is left at `0.0.0-placeholder-version` per the existing release convention — this PR does not bump it.