### PR TITLE
fix(xml_db): accept KeePassXC PreviousParentGroup element

### DIFF
--- a/src/format/xml_db/entry.rs
+++ b/src/format/xml_db/entry.rs
@@ -57,6 +57,13 @@ pub struct Entry {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_data: Option<CustomData>,
+
+    /// KeePassXC extension: tracks the previous parent group when this entry
+    /// is moved between groups, used for undo/restore. Captured here so the
+    /// element is consumed by an explicit field rather than tripping the
+    /// strict serde deserializer.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "cs_opt_string")]
+    pub previous_parent_group: Option<UUID>,
 }
 
 impl Entry {
@@ -508,12 +515,17 @@ mod tests {
                 <DataTransferObfuscation>0</DataTransferObfuscation>
                 <DefaultSequence>{USERNAME}{TAB}{PASSWORD}{ENTER}</DefaultSequence>
             </AutoType>
+            <PreviousParentGroup>oaKjpLGywcLR0tPU1dbX2A==</PreviousParentGroup>
         </Entry>"#;
 
         let deserialized: Test<Entry> = quick_xml::de::from_str(xml).unwrap();
         assert_eq!(
             deserialized.0.uuid.0.as_bytes(),
             &[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]
+        );
+        assert_eq!(
+            deserialized.0.previous_parent_group.unwrap().0.to_string(),
+            "a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8"
         );
         assert_eq!(deserialized.0.icon_id.unwrap(), 1);
         assert_eq!(deserialized.0.foreground_color.unwrap().to_string(), "#FF0000");

--- a/src/format/xml_db/group.rs
+++ b/src/format/xml_db/group.rs
@@ -53,6 +53,13 @@ pub struct Group {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_data: Option<crate::format::xml_db::meta::CustomData>,
 
+    /// KeePassXC extension: tracks the previous parent group when this group
+    /// is moved, used for undo/restore. Captured here so it is consumed by an
+    /// explicit field instead of falling through to the `children` $value
+    /// catch-all (which would fail to deserialize as a `GroupOrEntry`).
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "cs_opt_string")]
+    pub previous_parent_group: Option<UUID>,
+
     #[serde(default, rename = "$value")]
     pub children: Vec<GroupOrEntry>,
 }
@@ -205,10 +212,15 @@ mod tests {
             <Entry>
                 <UUID>AAECAwQFBgcICQoLDA0ODw==</UUID>
             </Entry>
+            <PreviousParentGroup>oaKjpLGywcLR0tPU1dbX2A==</PreviousParentGroup>
         </Group>"#;
 
         let group: Test<Group> = quick_xml::de::from_str(xml).unwrap();
         assert_eq!(group.0.uuid.0.to_string(), "00010203-0405-0607-0809-0a0b0c0d0e0f");
+        assert_eq!(
+            group.0.previous_parent_group.unwrap().0.to_string(),
+            "a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8"
+        );
         assert_eq!(group.0.name, "Example Group");
         assert_eq!(group.0.notes.unwrap(), "This is a test group.");
         assert_eq!(group.0.icon_id.unwrap(), 48);


### PR DESCRIPTION
## Summary

KeePassXC writes a `<PreviousParentGroup>UUID</PreviousParentGroup>` element on `Group` and `Entry` to record the previous parent group when items are moved between groups (used for the undo/restore feature, [KeePassXC #5544](https://github.com/keepassxreboot/keepassxc/pull/5544), shipped in 2.7.x).

`keepass-rs` currently fails to deserialize any KDBX file containing this element. On `Group`, the element falls through to the `children: Vec<GroupOrEntry>` `$value` catch-all and the deserializer errors with:

```
Error parsing XML inside KDBX: unknown variant `PreviousParentGroup`, expected `Group` or `Entry`
```

This blocks reads of any KeePassXC database after the user has moved an entry between groups (which is increasingly common — the move is recorded automatically).

## Fix

Add an explicit `previous_parent_group: Option<UUID>` named field on both `Group` and `Entry` (PascalCase rename via the existing struct-level attr, decoded with the existing `cs_opt_string` helper). Now the element is consumed by a known field instead of routing to the children stream.

The value is captured but not yet plumbed through to the in-memory `Group`/`Entry` model — round-trip preservation on save would require a follow-up. For now this is a read-fix only; the field is `skip_serializing_if = \"Option::is_none\"` so it doesn't appear when re-saving databases that didn't carry it.

## Test plan

- [x] Added regression cases in `test_deserialize_group` and `test_deserialize_entry` exercising the `<PreviousParentGroup>` element.
- [x] `cargo test --lib format::xml_db` passes (24 tests, 0 failed).
- [x] Manually validated against a real KeePassXC 2.7.x kdbx file containing moved entries — opens cleanly post-fix; same file errors with the message above on `master`.