### PR TITLE
feat(entry): add attachments_named() iterator on EntryRef

### DIFF
--- a/src/db/types/entry.rs
+++ b/src/db/types/entry.rs
@@ -230,6 +230,17 @@ impl EntryRef<'_> {
             .map(move |attachment_id| AttachmentRef::new(self.database, attachment_id))
     }
 
+    /// Get an iterator over the (name, attachment) pairs of this entry.
+    ///
+    /// Useful when callers need both the attachment's filename (the key under
+    /// which it is stored on the entry) and its data, since [`AttachmentRef`]
+    /// itself does not expose the per-entry name.
+    pub fn attachments_named(&self) -> impl Iterator<Item = (&str, AttachmentRef<'_>)> {
+        self.attachments.iter().map(move |(name, &attachment_id)| {
+            (name.as_str(), AttachmentRef::new(self.database, attachment_id))
+        })
+    }
+
     /// Get the custom icon of this entry, if it exists and is a custom icon.
     pub fn custom_icon(&self) -> Option<CustomIconRef<'_>> {
         if let Some(Icon::Custom(custom_icon_id)) = self.icon {

--- a/src/format/kdbx4/mod.rs
+++ b/src/format/kdbx4/mod.rs
@@ -230,6 +230,20 @@ mod kdbx4_tests {
             entry.attachment_by_name("file2.txt").unwrap().get(),
             &[0x04, 0x03, 0x02, 0x01]
         );
+
+        // attachments_named() yields (name, AttachmentRef) pairs, allowing callers
+        // to recover the per-entry filename without a separate lookup.
+        let mut seen = std::collections::HashSet::new();
+        for (name, attachment) in entry.attachments_named() {
+            let expected: &[u8] = match name {
+                "file1.txt" => &[0x01, 0x02, 0x03, 0x04],
+                "file2.txt" => &[0x04, 0x03, 0x02, 0x01],
+                _ => panic!("unexpected attachment name: {}", name),
+            };
+            assert_eq!(attachment.get(), expected);
+            assert!(seen.insert(name.to_owned()), "duplicate name: {}", name);
+        }
+        assert_eq!(seen.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Closes #314.

Adds `EntryRef::attachments_named()`, returning an iterator of `(&str, AttachmentRef)` pairs. Mirrors the existing `attachments()` shape but yields the per-entry filename alongside each `AttachmentRef`, so callers don't need a second lookup via `attachment_by_name`.

## Why

`AttachmentRef` doesn't expose the per-entry filename (the key under which an attachment is stored on the entry). To get a `(name, data)` listing today, callers either:
- know the names ahead of time and call `attachment_by_name` per name, or
- enable the `serialization` feature and serialize the entry through JSON to extract the names.

Both are heavier than the natural iterator pattern.

## Implementation

11 lines on `EntryRef`. Uses `self.attachments.iter()` (HashMap iteration), maps each `(name, &id)` into `(name.as_str(), AttachmentRef::new(self.database, id))`. `AttachmentId` is `Copy`, so no clone needed.

## Test

Extends the existing `format::kdbx4::kdbx4_tests::test_attachments` roundtrip (which already creates two attachments with known data). Adds an inline iteration that asserts each `(name, AttachmentRef)` pair returns the expected bytes and that all names are unique.

Verified locally:
- `cargo build` clean
- `cargo test --all-features` all pass
- `cargo clippy --all-features` clean
- `cargo fmt --check` clean

## Notes

- Purely additive; no public API removed or changed.
- Iteration order is HashMap-based, matching `attachments()`.
- This is scoped to the `attachments_named()` part of #314. The UUID-setter / `History.entries` parts are separate (still discussing the consistency-check boundary on the issue thread).