### PR TITLE
test: add clean-room kdbx spec test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ base32 = { version = "0.5", optional = true }
 rustfmt = "0.10"
 tempfile = "3"
 rand = "0.8"
+test-with = { version = "0.16", default-features = false, features = ["executable"] }
 
 # Browser-only deps: wasm32-unknown-unknown is the canonical browser target.
 # wasi-flavoured wasm32 targets (wasm32-wasip1, wasm32-wasip2) use their own

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,8 @@ base32 = { version = "0.5", optional = true }
 # wasm32 causes build failures, so we keep it as a dev-dependency but exclude it
 # on wasm.
 rustfmt = "0.10"
+tempfile = "3"
+rand = "0.8"
 
 # Browser-only deps: wasm32-unknown-unknown is the canonical browser target.
 # wasi-flavoured wasm32 targets (wasm32-wasip1, wasm32-wasip2) use their own

--- a/tests/binary_pool.rs
+++ b/tests/binary_pool.rs
@@ -1,25 +1,15 @@
+#![cfg(feature = "save_kdbx4")]
 #![forbid(unsafe_code)]
 
 mod common;
 
-use common::{combo_by_label, config_and_key_for};
-use keepass::{
-    config::DatabaseConfig,
-    db::{Database, Value},
-    DatabaseKey,
-};
+use common::combo_by_label;
+use keepass::db::{Database, Value};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 
-fn baseline_setup() -> (DatabaseConfig, DatabaseKey, impl Fn() -> DatabaseKey) {
-    let combo = combo_by_label("aes256+none+inner-chacha20+argon2d");
-    let (cfg, key) = config_and_key_for(&combo);
-    let reopen_key = move || config_and_key_for(&combo).1;
-    (cfg, key, reopen_key)
-}
-
 fn drive(label: &str, payloads: Vec<Vec<u8>>) {
-    let (cfg, key, reopen_key) = baseline_setup();
-    let mut db = Database::with_config(cfg);
+    let combo = combo_by_label("aes256+none+inner-chacha20+argon2d");
+    let mut db = Database::with_config(combo.get_config());
 
     {
         let mut root = db.root_mut();
@@ -30,8 +20,8 @@ fn drive(label: &str, payloads: Vec<Vec<u8>>) {
         }
     }
 
-    let bytes = common::save_to_vec(&db, key);
-    let parsed = Database::open(&mut bytes.as_slice(), reopen_key())
+    let bytes = common::save_to_vec(&db, combo.get_key());
+    let parsed = Database::open(&mut bytes.as_slice(), combo.get_key())
         .unwrap_or_else(|err| panic!("{}: reopen failed: {:?}", label, err));
 
     assert_eq!(

--- a/tests/binary_pool.rs
+++ b/tests/binary_pool.rs
@@ -1,0 +1,98 @@
+#![forbid(unsafe_code)]
+
+mod common;
+
+use common::{combo_by_label, config_and_key_for};
+use keepass::{
+    config::DatabaseConfig,
+    db::{Database, Value},
+    DatabaseKey,
+};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+
+fn baseline_setup() -> (DatabaseConfig, DatabaseKey, impl Fn() -> DatabaseKey) {
+    let combo = combo_by_label("aes256+none+inner-chacha20+argon2d");
+    let (cfg, key) = config_and_key_for(&combo);
+    let reopen_key = move || config_and_key_for(&combo).1;
+    (cfg, key, reopen_key)
+}
+
+fn drive(label: &str, payloads: Vec<Vec<u8>>) {
+    let (cfg, key, reopen_key) = baseline_setup();
+    let mut db = Database::with_config(cfg);
+
+    {
+        let mut root = db.root_mut();
+        let mut e = root.add_entry();
+        e.set_unprotected("Title", "attachments");
+        for (i, content) in payloads.iter().enumerate() {
+            e.add_attachment(format!("blob-{i}.bin"), Value::Unprotected(content.clone()));
+        }
+    }
+
+    let bytes = common::save_to_vec(&db, key);
+    let parsed = Database::open(&mut bytes.as_slice(), reopen_key())
+        .unwrap_or_else(|err| panic!("{}: reopen failed: {:?}", label, err));
+
+    assert_eq!(
+        parsed.num_attachments(),
+        payloads.len(),
+        "{}: total attachments count",
+        label
+    );
+
+    let root = parsed.root();
+    let entry = root
+        .entries()
+        .next()
+        .unwrap_or_else(|| panic!("{}: no entry under root", label));
+
+    for (i, expected) in payloads.iter().enumerate() {
+        let name = format!("blob-{i}.bin");
+        let att = entry
+            .attachment_by_name(&name)
+            .unwrap_or_else(|| panic!("{}: missing attachment {}", label, name));
+        assert_eq!(
+            att.data.get().as_slice(),
+            expected.as_slice(),
+            "{}: payload {} differs",
+            label,
+            i
+        );
+    }
+}
+
+#[test]
+fn binary_pool_sizes_zero_one_sixteen() {
+    drive("sizes-tiny", vec![Vec::new(), vec![0x00], (0u8..16).collect()]);
+}
+
+#[test]
+fn binary_pool_4kib_random() {
+    let mut buf = vec![0u8; 4 * 1024];
+    StdRng::seed_from_u64(0x1234_5678).fill_bytes(&mut buf);
+    drive("sizes-4kib", vec![buf]);
+}
+
+#[test]
+fn binary_pool_1mib_random() {
+    let mut buf = vec![0u8; 1024 * 1024];
+    StdRng::seed_from_u64(0x9876_5432).fill_bytes(&mut buf);
+    drive("sizes-1mib", vec![buf]);
+}
+
+#[test]
+fn binary_pool_byte_patterns() {
+    drive(
+        "byte-patterns",
+        vec![
+            vec![0u8; 256],
+            vec![0xFFu8; 256],
+            (0..=255u8).collect(),
+            vec![
+                0xC3, 0x28, 0xA0, 0xA1, 0xE2, 0x28, 0xA1, 0xE2, 0x82, 0x28, 0xF0, 0x28, 0x8C, 0xBC, 0xF0, 0x90,
+                0x28, 0xBC, 0xF0, 0x28, 0x8C, 0x28,
+            ],
+        ],
+    );
+}

--- a/tests/broken_files.rs
+++ b/tests/broken_files.rs
@@ -1,34 +1,34 @@
+#![cfg(feature = "save_kdbx4")]
 #![forbid(unsafe_code)]
 
 mod common;
 
-use std::panic::{catch_unwind, AssertUnwindSafe};
-
-use common::{combo_by_label, config_and_key_for, fast_combo, minimal_database, DEMO_PASSWORD};
+use common::{combo_by_label, fast_combo, DEMO_PASSWORD};
+use keepass::error::{DatabaseKeyError, DatabaseOpenError, DatabaseVersionParseError};
 use keepass::{Database, DatabaseKey};
 
 fn baseline_blob() -> (Vec<u8>, DatabaseKey) {
     let combo = fast_combo();
-    let (cfg, key) = config_and_key_for(&combo);
-    let db = minimal_database(cfg);
-    let bytes = common::save_to_vec(&db, key);
-    (bytes, config_and_key_for(&combo).1)
-}
-
-fn assert_clean_error(blob: &[u8], key: DatabaseKey, label: &str) -> Result<(), String> {
-    let res = catch_unwind(AssertUnwindSafe(|| Database::open(&mut &blob[..], key)));
-    match res {
-        Ok(Ok(_)) => Err(format!("{label}: parser returned Ok on broken input")),
-        Ok(Err(_)) => Ok(()),
-        Err(_) => Err(format!("{label}: parser PANICKED on broken input")),
-    }
+    let db = combo.minimal_database();
+    let bytes = common::save_to_vec(&db, combo.get_key());
+    (bytes, combo.get_key())
 }
 
 #[test]
 fn mutation_bad_magic() {
     let (mut blob, key) = baseline_blob();
     blob[0] ^= 0xFF;
-    assert_clean_error(&blob, key, "BadMagic").unwrap();
+    let res = Database::open(&mut &blob[..], key);
+    assert!(
+        matches!(
+            res,
+            Err(DatabaseOpenError::VersionParse(
+                DatabaseVersionParseError::InvalidKDBXIdentifier
+            ))
+        ),
+        "BadMagic: unexpected result: {:?}",
+        res
+    );
 }
 
 #[test]
@@ -36,7 +36,17 @@ fn mutation_bad_kdbx_version() {
     let (mut blob, key) = baseline_blob();
     blob[10] = 5;
     blob[11] = 0;
-    assert_clean_error(&blob, key, "BadKdbxVersion").unwrap();
+    let res = Database::open(&mut &blob[..], key);
+    assert!(
+        matches!(
+            res,
+            Err(DatabaseOpenError::VersionParse(
+                DatabaseVersionParseError::InvalidKDBXVersion { .. }
+            ))
+        ),
+        "BadKdbxVersion: unexpected result: {:?}",
+        res
+    );
 }
 
 #[test]
@@ -44,14 +54,16 @@ fn mutation_truncated_at_header() {
     let (blob, key) = baseline_blob();
     let cut = (blob.len() / 4).clamp(20, 80);
     let truncated = &blob[..cut];
-    assert_clean_error(truncated, key, "TruncatedAtHeader").unwrap();
+    let res = Database::open(&mut &truncated[..], key);
+    assert!(res.is_err(), "TruncatedAtHeader: expected Err, got Ok");
 }
 
 #[test]
 fn mutation_truncated_at_payload() {
     let (blob, key) = baseline_blob();
     let truncated = &blob[..blob.len() - 8];
-    assert_clean_error(truncated, key, "TruncatedAtPayload").unwrap();
+    let res = Database::open(&mut &truncated[..], key);
+    assert!(res.is_err(), "TruncatedAtPayload: expected Err, got Ok");
 }
 
 #[test]
@@ -59,7 +71,8 @@ fn mutation_bad_header_sha256() {
     let (mut blob, key) = baseline_blob();
     let header_end = locate_header_end(&blob).expect("locate header end");
     blob[header_end] ^= 0x01;
-    assert_clean_error(&blob, key, "BadHeaderSha256").unwrap();
+    let res = Database::open(&mut &blob[..], key);
+    assert!(res.is_err(), "BadHeaderSha256: expected Err, got Ok");
 }
 
 #[test]
@@ -67,7 +80,8 @@ fn mutation_bad_header_hmac() {
     let (mut blob, key) = baseline_blob();
     let header_end = locate_header_end(&blob).expect("locate header end");
     blob[header_end + 32 + 1] ^= 0x80;
-    assert_clean_error(&blob, key, "BadHeaderHmac").unwrap();
+    let res = Database::open(&mut &blob[..], key);
+    assert!(res.is_err(), "BadHeaderHmac: expected Err, got Ok");
 }
 
 #[test]
@@ -78,7 +92,8 @@ fn mutation_bad_inner_header() {
     if target < blob.len() {
         blob[target] ^= 0xAA;
     }
-    assert_clean_error(&blob, key, "BadInnerHeader").unwrap();
+    let res = Database::open(&mut &blob[..], key);
+    assert!(res.is_err(), "BadInnerHeader: expected Err, got Ok");
 }
 
 #[test]
@@ -86,7 +101,8 @@ fn mutation_bad_cipher_id() {
     let (mut blob, key) = baseline_blob();
     let cipher_off = locate_header_field(&blob, 2).expect("locate cipher id");
     blob[cipher_off + 1] ^= 0xFF;
-    assert_clean_error(&blob, key, "BadCipherId").unwrap();
+    let res = Database::open(&mut &blob[..], key);
+    assert!(res.is_err(), "BadCipherId: expected Err, got Ok");
 }
 
 #[test]
@@ -95,34 +111,36 @@ fn mutation_bad_kdf_params() {
     let kdf_off = locate_header_field(&blob, 11).expect("locate kdf params");
     blob[kdf_off] = 0xFF;
     blob[kdf_off + 1] = 0x7F;
-    assert_clean_error(&blob, key, "BadKdfParams").unwrap();
+    let res = Database::open(&mut &blob[..], key);
+    assert!(res.is_err(), "BadKdfParams: expected Err, got Ok");
 }
 
 #[test]
 fn mutation_data_after_end() {
     let (mut blob, key) = baseline_blob();
     blob.extend_from_slice(&[0u8; 64]);
-    let res = catch_unwind(AssertUnwindSafe(|| Database::open(&mut &blob[..], key)));
-    if res.is_err() {
-        panic!("DataAfterEnd: parser PANICKED on trailing bytes");
-    }
+    // Trailing-byte tolerance is reader-defined; either Ok or Err is fine,
+    // we just don't want a panic. The test framework already fails on panic.
+    let _ = Database::open(&mut &blob[..], key);
 }
 
 #[test]
 fn mutation_wrong_password() {
     let (blob, _key) = baseline_blob();
     let wrong = DatabaseKey::new().with_password("not-the-password");
-    if Database::open(&mut &blob[..], wrong).is_ok() {
-        panic!("WrongPassword: opened with wrong password");
-    }
+    let res = Database::open(&mut &blob[..], wrong);
+    assert!(
+        matches!(res, Err(DatabaseOpenError::Key(DatabaseKeyError::IncorrectKey))),
+        "WrongPassword: unexpected result: {:?}",
+        res
+    );
 }
 
 #[test]
 fn mutation_keyfile_mismatch() {
     let combo = combo_by_label("aes256+gz+inner-chacha20+argon2d+pw+kf-raw32");
-    let (cfg, key) = config_and_key_for(&combo);
-    let db = minimal_database(cfg);
-    let bytes = common::save_to_vec(&db, key);
+    let db = combo.minimal_database();
+    let bytes = common::save_to_vec(&db, combo.get_key());
 
     let mut wrong_keyfile = vec![0u8; 32];
     wrong_keyfile[0] = 0xAA;
@@ -131,9 +149,12 @@ fn mutation_keyfile_mismatch() {
         .with_keyfile(&mut std::io::Cursor::new(wrong_keyfile))
         .expect("keyfile parse");
 
-    if Database::open(&mut &bytes[..], wrong).is_ok() {
-        panic!("KeyfileMismatch: opened with wrong keyfile");
-    }
+    let res = Database::open(&mut &bytes[..], wrong);
+    assert!(
+        matches!(res, Err(DatabaseOpenError::Key(DatabaseKeyError::IncorrectKey))),
+        "KeyfileMismatch: unexpected result: {:?}",
+        res
+    );
 }
 
 fn locate_header_end(blob: &[u8]) -> Option<usize> {

--- a/tests/broken_files.rs
+++ b/tests/broken_files.rs
@@ -1,0 +1,166 @@
+#![forbid(unsafe_code)]
+
+mod common;
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use common::{combo_by_label, config_and_key_for, fast_combo, minimal_database, DEMO_PASSWORD};
+use keepass::{Database, DatabaseKey};
+
+fn baseline_blob() -> (Vec<u8>, DatabaseKey) {
+    let combo = fast_combo();
+    let (cfg, key) = config_and_key_for(&combo);
+    let db = minimal_database(cfg);
+    let bytes = common::save_to_vec(&db, key);
+    (bytes, config_and_key_for(&combo).1)
+}
+
+fn assert_clean_error(blob: &[u8], key: DatabaseKey, label: &str) -> Result<(), String> {
+    let res = catch_unwind(AssertUnwindSafe(|| Database::open(&mut &blob[..], key)));
+    match res {
+        Ok(Ok(_)) => Err(format!("{label}: parser returned Ok on broken input")),
+        Ok(Err(_)) => Ok(()),
+        Err(_) => Err(format!("{label}: parser PANICKED on broken input")),
+    }
+}
+
+#[test]
+fn mutation_bad_magic() {
+    let (mut blob, key) = baseline_blob();
+    blob[0] ^= 0xFF;
+    assert_clean_error(&blob, key, "BadMagic").unwrap();
+}
+
+#[test]
+fn mutation_bad_kdbx_version() {
+    let (mut blob, key) = baseline_blob();
+    blob[10] = 5;
+    blob[11] = 0;
+    assert_clean_error(&blob, key, "BadKdbxVersion").unwrap();
+}
+
+#[test]
+fn mutation_truncated_at_header() {
+    let (blob, key) = baseline_blob();
+    let cut = (blob.len() / 4).clamp(20, 80);
+    let truncated = &blob[..cut];
+    assert_clean_error(truncated, key, "TruncatedAtHeader").unwrap();
+}
+
+#[test]
+fn mutation_truncated_at_payload() {
+    let (blob, key) = baseline_blob();
+    let truncated = &blob[..blob.len() - 8];
+    assert_clean_error(truncated, key, "TruncatedAtPayload").unwrap();
+}
+
+#[test]
+fn mutation_bad_header_sha256() {
+    let (mut blob, key) = baseline_blob();
+    let header_end = locate_header_end(&blob).expect("locate header end");
+    blob[header_end] ^= 0x01;
+    assert_clean_error(&blob, key, "BadHeaderSha256").unwrap();
+}
+
+#[test]
+fn mutation_bad_header_hmac() {
+    let (mut blob, key) = baseline_blob();
+    let header_end = locate_header_end(&blob).expect("locate header end");
+    blob[header_end + 32 + 1] ^= 0x80;
+    assert_clean_error(&blob, key, "BadHeaderHmac").unwrap();
+}
+
+#[test]
+fn mutation_bad_inner_header() {
+    let (mut blob, key) = baseline_blob();
+    let header_end = locate_header_end(&blob).expect("locate header end");
+    let target = header_end + 32 + 32 + 8;
+    if target < blob.len() {
+        blob[target] ^= 0xAA;
+    }
+    assert_clean_error(&blob, key, "BadInnerHeader").unwrap();
+}
+
+#[test]
+fn mutation_bad_cipher_id() {
+    let (mut blob, key) = baseline_blob();
+    let cipher_off = locate_header_field(&blob, 2).expect("locate cipher id");
+    blob[cipher_off + 1] ^= 0xFF;
+    assert_clean_error(&blob, key, "BadCipherId").unwrap();
+}
+
+#[test]
+fn mutation_bad_kdf_params() {
+    let (mut blob, key) = baseline_blob();
+    let kdf_off = locate_header_field(&blob, 11).expect("locate kdf params");
+    blob[kdf_off] = 0xFF;
+    blob[kdf_off + 1] = 0x7F;
+    assert_clean_error(&blob, key, "BadKdfParams").unwrap();
+}
+
+#[test]
+fn mutation_data_after_end() {
+    let (mut blob, key) = baseline_blob();
+    blob.extend_from_slice(&[0u8; 64]);
+    let res = catch_unwind(AssertUnwindSafe(|| Database::open(&mut &blob[..], key)));
+    if res.is_err() {
+        panic!("DataAfterEnd: parser PANICKED on trailing bytes");
+    }
+}
+
+#[test]
+fn mutation_wrong_password() {
+    let (blob, _key) = baseline_blob();
+    let wrong = DatabaseKey::new().with_password("not-the-password");
+    if Database::open(&mut &blob[..], wrong).is_ok() {
+        panic!("WrongPassword: opened with wrong password");
+    }
+}
+
+#[test]
+fn mutation_keyfile_mismatch() {
+    let combo = combo_by_label("aes256+gz+inner-chacha20+argon2d+pw+kf-raw32");
+    let (cfg, key) = config_and_key_for(&combo);
+    let db = minimal_database(cfg);
+    let bytes = common::save_to_vec(&db, key);
+
+    let mut wrong_keyfile = vec![0u8; 32];
+    wrong_keyfile[0] = 0xAA;
+    let wrong = DatabaseKey::new()
+        .with_password(DEMO_PASSWORD)
+        .with_keyfile(&mut std::io::Cursor::new(wrong_keyfile))
+        .expect("keyfile parse");
+
+    if Database::open(&mut &bytes[..], wrong).is_ok() {
+        panic!("KeyfileMismatch: opened with wrong keyfile");
+    }
+}
+
+fn locate_header_end(blob: &[u8]) -> Option<usize> {
+    let mut off = 12usize;
+    while off + 5 <= blob.len() {
+        let tag = blob[off];
+        let len = u32::from_le_bytes([blob[off + 1], blob[off + 2], blob[off + 3], blob[off + 4]]) as usize;
+        off += 5 + len;
+        if tag == 0 {
+            return Some(off);
+        }
+    }
+    None
+}
+
+fn locate_header_field(blob: &[u8], tag_wanted: u8) -> Option<usize> {
+    let mut off = 12usize;
+    while off + 5 <= blob.len() {
+        let tag = blob[off];
+        let len = u32::from_le_bytes([blob[off + 1], blob[off + 2], blob[off + 3], blob[off + 4]]) as usize;
+        if tag == tag_wanted {
+            return Some(off + 5);
+        }
+        off += 5 + len;
+        if tag == 0 {
+            break;
+        }
+    }
+    None
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -180,7 +180,7 @@ pub fn combo_by_label(label: &str) -> Combo {
     round_trip_combos()
         .into_iter()
         .find(|c| c.label == label)
-        .unwrap_or_else(|| panic!("combo {label} not in matrix"))
+        .unwrap_or_else(|| panic!("combo {} not in matrix", label))
 }
 
 pub fn baseline_combo() -> Combo {
@@ -191,119 +191,125 @@ pub fn fast_combo() -> Combo {
     combo_by_label("aes256+none+inner-chacha20+aeskdf")
 }
 
-pub fn config_and_key_for(combo: &Combo) -> (DatabaseConfig, DatabaseKey) {
-    let mut cfg = DatabaseConfig::default();
-    cfg.version = DatabaseVersion::KDB4(0);
-    cfg.outer_cipher_config = combo.outer_cipher.clone();
-    cfg.compression_config = combo.compression.clone();
-    cfg.inner_cipher_config = combo.inner_cipher.clone();
-    cfg.kdf_config = combo.kdf.clone();
-    cfg.public_custom_data = None;
-    let key = match &combo.master_key {
-        MasterKey::Password(p) => DatabaseKey::new().with_password(p),
-        MasterKey::Keyfile(k) => {
-            let bytes = k.to_bytes();
-            DatabaseKey::new()
-                .with_keyfile(&mut Cursor::new(bytes))
-                .expect("keyfile read")
-        }
-        MasterKey::PasswordAndKeyfile(p, k) => {
-            let bytes = k.to_bytes();
-            DatabaseKey::new()
-                .with_password(p)
-                .with_keyfile(&mut Cursor::new(bytes))
-                .expect("keyfile read")
-        }
-    };
-    (cfg, key)
-}
+impl Combo {
+    pub fn get_config(&self) -> DatabaseConfig {
+        let mut cfg = DatabaseConfig::default();
+        cfg.version = DatabaseVersion::KDB4(0);
+        cfg.outer_cipher_config = self.outer_cipher.clone();
+        cfg.compression_config = self.compression.clone();
+        cfg.inner_cipher_config = self.inner_cipher.clone();
+        cfg.kdf_config = self.kdf.clone();
+        cfg.public_custom_data = None;
+        cfg
+    }
 
-pub fn rich_database(config: DatabaseConfig) -> Database {
-    use chrono::NaiveDate;
-
-    let mut db = Database::with_config(config);
-    db.meta.generator = Some("keepass-spec-tests".to_string());
-    db.meta.database_name = Some("rich-fixture".to_string());
-    db.meta.database_description = Some("test fixture".to_string());
-
-    db.meta.custom_data.insert(
-        "fixture.kind".to_string(),
-        CustomDataItem {
-            value: Some(CustomDataValue::String("rich".to_string())),
-            last_modification_time: None,
-        },
-    );
-
-    let mut first_entry_id = None;
-    for i in 0..10 {
-        let mut root = db.root_mut();
-        let mut e = root.add_entry();
-        e.set_unprotected("Title", format!("entry-{i:02}"));
-        e.set_unprotected("UserName", format!("user-{i:02}"));
-        e.set_protected("Password", format!("pw-{i:02}"));
-        e.set_unprotected("URL", format!("https://example.invalid/{i}"));
-        e.set_unprotected(format!("custom.unprotected.{i}"), format!("plain-{i}"));
-        e.set_protected(format!("custom.protected.{i}"), format!("secret-{i}"));
-        if i % 2 == 0 {
-            e.tags = vec![format!("tag-{i}"), "fixture".to_string()];
-            e.times.expires = Some(true);
-            e.times.expiry = Some(
-                NaiveDate::from_ymd_opt(2099, 12, 31)
-                    .unwrap()
-                    .and_hms_opt(23, 59, 59)
-                    .unwrap(),
-            );
-        }
-        e.custom_data.insert(
-            format!("entry.cd.{i}"),
-            CustomDataItem {
-                value: Some(CustomDataValue::String(format!("cd-{i}"))),
-                last_modification_time: None,
-            },
-        );
-        if i == 0 {
-            first_entry_id = Some(e.id());
+    pub fn get_key(&self) -> DatabaseKey {
+        match &self.master_key {
+            MasterKey::Password(p) => DatabaseKey::new().with_password(p),
+            MasterKey::Keyfile(k) => {
+                let bytes = k.to_bytes();
+                DatabaseKey::new()
+                    .with_keyfile(&mut Cursor::new(bytes))
+                    .expect("keyfile read")
+            }
+            MasterKey::PasswordAndKeyfile(p, k) => {
+                let bytes = k.to_bytes();
+                DatabaseKey::new()
+                    .with_password(p)
+                    .with_keyfile(&mut Cursor::new(bytes))
+                    .expect("keyfile read")
+            }
         }
     }
 
-    let bin_uuid = {
+    pub fn minimal_database(&self) -> Database {
+        let mut db = Database::with_config(self.get_config());
         let mut root = db.root_mut();
-        let mut rec_bin = root.add_group();
-        rec_bin.name = "Recycle Bin".to_string();
-        let bin_id = rec_bin.id();
-        let mut rec_entry = rec_bin.add_entry();
-        rec_entry.set_unprotected("Title", "deleted-entry");
-        bin_id.uuid()
-    };
-    db.meta.recyclebin_enabled = Some(true);
-    db.meta.recyclebin_uuid = Some(bin_uuid);
+        let mut e = root.add_entry();
+        e.set_unprotected("Title", "only-entry");
+        db
+    }
 
-    let first_id = first_entry_id.expect("at least one entry created");
-    let mut e = db.entry_mut(first_id).expect("first entry exists");
-    e.add_attachment("small.bin", Value::Unprotected(b"small".to_vec()));
-    let noise = {
-        let mut buf = vec![0u8; 4 * 1024];
-        let mut r = StdRng::seed_from_u64(MASTER_SEED ^ 0xA);
-        r.fill_bytes(&mut buf);
-        buf
-    };
-    e.add_attachment("noise.bin", Value::Unprotected(noise));
-    e.add_attachment(
-        "nonutf8.bin",
-        Value::Unprotected(vec![0xFF, 0xFE, 0xFD, 0x80, 0x81, 0x82, 0x00, 0x01]),
-    );
+    pub fn rich_database(&self) -> Database {
+        use chrono::NaiveDate;
 
-    db
+        let mut db = Database::with_config(self.get_config());
+        db.meta.generator = Some("keepass-spec-tests".to_string());
+        db.meta.database_name = Some("rich-fixture".to_string());
+        db.meta.database_description = Some("test fixture".to_string());
+
+        db.meta.custom_data.insert(
+            "fixture.kind".to_string(),
+            CustomDataItem {
+                value: Some(CustomDataValue::String("rich".to_string())),
+                last_modification_time: None,
+            },
+        );
+
+        let mut first_entry_id = None;
+        for i in 0..10 {
+            let mut root = db.root_mut();
+            let mut e = root.add_entry();
+            e.set_unprotected("Title", format!("entry-{i:02}"));
+            e.set_unprotected("UserName", format!("user-{i:02}"));
+            e.set_protected("Password", format!("pw-{i:02}"));
+            e.set_unprotected("URL", format!("https://example.invalid/{i}"));
+            e.set_unprotected(format!("custom.unprotected.{i}"), format!("plain-{i}"));
+            e.set_protected(format!("custom.protected.{i}"), format!("secret-{i}"));
+            if i % 2 == 0 {
+                e.tags = vec![format!("tag-{i}"), "fixture".to_string()];
+                e.times.expires = Some(true);
+                e.times.expiry = Some(
+                    NaiveDate::from_ymd_opt(2099, 12, 31)
+                        .unwrap()
+                        .and_hms_opt(23, 59, 59)
+                        .unwrap(),
+                );
+            }
+            e.custom_data.insert(
+                format!("entry.cd.{i}"),
+                CustomDataItem {
+                    value: Some(CustomDataValue::String(format!("cd-{i}"))),
+                    last_modification_time: None,
+                },
+            );
+            if i == 0 {
+                first_entry_id = Some(e.id());
+            }
+        }
+
+        let bin_uuid = {
+            let mut root = db.root_mut();
+            let mut rec_bin = root.add_group();
+            rec_bin.name = "Recycle Bin".to_string();
+            let bin_id = rec_bin.id();
+            let mut rec_entry = rec_bin.add_entry();
+            rec_entry.set_unprotected("Title", "deleted-entry");
+            bin_id.uuid()
+        };
+        db.meta.recyclebin_enabled = Some(true);
+        db.meta.recyclebin_uuid = Some(bin_uuid);
+
+        let first_id = first_entry_id.expect("at least one entry created");
+        let mut e = db.entry_mut(first_id).expect("first entry exists");
+        e.add_attachment("small.bin", Value::Unprotected(b"small".to_vec()));
+        let noise = {
+            let mut buf = vec![0u8; 4 * 1024];
+            let mut r = StdRng::seed_from_u64(MASTER_SEED ^ 0xA);
+            r.fill_bytes(&mut buf);
+            buf
+        };
+        e.add_attachment("noise.bin", Value::Unprotected(noise));
+        e.add_attachment(
+            "nonutf8.bin",
+            Value::Unprotected(vec![0xFF, 0xFE, 0xFD, 0x80, 0x81, 0x82, 0x00, 0x01]),
+        );
+
+        db
+    }
 }
 
-pub fn minimal_database(config: DatabaseConfig) -> Database {
-    let mut db = Database::with_config(config);
-    let mut root = db.root_mut();
-    let mut e = root.add_entry();
-    e.set_unprotected("Title", "only-entry");
-    db
-}
-
+#[cfg(feature = "save_kdbx4")]
 pub fn save_to_vec(db: &Database, key: DatabaseKey) -> Vec<u8> {
     let mut buf = Vec::new();
     db.save(&mut buf, key).expect("save_to_vec: save failed");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,311 @@
+#![forbid(unsafe_code)]
+#![allow(dead_code)]
+
+use std::io::Cursor;
+
+use keepass::{
+    config::{
+        CompressionConfig, DatabaseConfig, DatabaseVersion, InnerCipherConfig, KdfConfig, OuterCipherConfig,
+    },
+    db::{CustomDataItem, CustomDataValue, Database, Value},
+    DatabaseKey,
+};
+
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+
+pub const MASTER_SEED: u64 = 0xdead_beef_cafe_f00d;
+pub const DEMO_PASSWORD: &str = "demopass";
+
+#[derive(Debug, Clone)]
+pub struct Combo {
+    pub label: &'static str,
+    pub outer_cipher: OuterCipherConfig,
+    pub compression: CompressionConfig,
+    pub inner_cipher: InnerCipherConfig,
+    pub kdf: KdfConfig,
+    pub master_key: MasterKey,
+}
+
+#[derive(Debug, Clone)]
+pub enum MasterKey {
+    Password(&'static str),
+    Keyfile(KeyfileKind),
+    PasswordAndKeyfile(&'static str, KeyfileKind),
+}
+
+#[derive(Debug, Clone)]
+pub enum KeyfileKind {
+    Raw32([u8; 32]),
+    Hex([u8; 32]),
+    XmlV1([u8; 32]),
+    XmlV2([u8; 32]),
+}
+
+impl KeyfileKind {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            KeyfileKind::Raw32(k) => k.to_vec(),
+            KeyfileKind::Hex(k) => hex::encode(k).into_bytes(),
+            KeyfileKind::XmlV1(k) => {
+                use base64::engine::general_purpose::STANDARD;
+                use base64::Engine as _;
+                let b64 = STANDARD.encode(k);
+                format!(
+                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<KeyFile>\n  <Meta><Version>1.00</Version></Meta>\n  <Key><Data>{b64}</Data></Key>\n</KeyFile>\n"
+                )
+                .into_bytes()
+            }
+            KeyfileKind::XmlV2(k) => {
+                let hex_lo = hex::encode(k).to_uppercase();
+                let line = |s: &str| -> String {
+                    let mut out = String::new();
+                    for (i, c) in s.chars().enumerate() {
+                        if i > 0 && i % 8 == 0 {
+                            out.push(' ');
+                        }
+                        out.push(c);
+                    }
+                    out
+                };
+                let l1 = line(&hex_lo[0..32]);
+                let l2 = line(&hex_lo[32..64]);
+                format!(
+                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<KeyFile>\n  <Meta><Version>2.0</Version></Meta>\n  <Key>\n    <Data Hash=\"00000000\">\n      {l1}\n      {l2}\n    </Data>\n  </Key>\n</KeyFile>\n"
+                )
+                .into_bytes()
+            }
+        }
+    }
+}
+
+pub fn seeded_rng() -> StdRng {
+    StdRng::seed_from_u64(MASTER_SEED)
+}
+
+pub fn fast_argon2() -> KdfConfig {
+    KdfConfig::Argon2 {
+        iterations: 1,
+        memory: 64 * 1024,
+        parallelism: 1,
+        version: argon2::Version::Version13,
+    }
+}
+
+pub fn fast_argon2id() -> KdfConfig {
+    KdfConfig::Argon2id {
+        iterations: 1,
+        memory: 64 * 1024,
+        parallelism: 1,
+        version: argon2::Version::Version13,
+    }
+}
+
+pub fn fast_aes_kdf() -> KdfConfig {
+    KdfConfig::Aes { rounds: 8 }
+}
+
+pub fn round_trip_combos() -> Vec<Combo> {
+    let mut combos = Vec::new();
+
+    let outer = [
+        ("aes256", OuterCipherConfig::AES256),
+        ("chacha20", OuterCipherConfig::ChaCha20),
+        ("twofish", OuterCipherConfig::Twofish),
+    ];
+    let comp = [("gz", CompressionConfig::GZip), ("none", CompressionConfig::None)];
+    let inner = [
+        ("inner-chacha20", InnerCipherConfig::ChaCha20),
+        ("inner-salsa20", InnerCipherConfig::Salsa20),
+    ];
+    let kdfs = [
+        ("aeskdf", fast_aes_kdf()),
+        ("argon2d", fast_argon2()),
+        ("argon2id", fast_argon2id()),
+    ];
+
+    for (oc_l, oc) in &outer {
+        for (cm_l, cm) in &comp {
+            for (ic_l, ic) in &inner {
+                for (kd_l, kd) in &kdfs {
+                    let label: &'static str =
+                        Box::leak(format!("{oc_l}+{cm_l}+{ic_l}+{kd_l}").into_boxed_str());
+                    combos.push(Combo {
+                        label,
+                        outer_cipher: oc.clone(),
+                        compression: cm.clone(),
+                        inner_cipher: ic.clone(),
+                        kdf: kd.clone(),
+                        master_key: MasterKey::Password(DEMO_PASSWORD),
+                    });
+                }
+            }
+        }
+    }
+
+    let mut keyfile_seed = [0u8; 32];
+    let mut rng = seeded_rng();
+    rng.fill_bytes(&mut keyfile_seed);
+    let kinds = [
+        ("kf-raw32", KeyfileKind::Raw32(keyfile_seed)),
+        ("kf-hex", KeyfileKind::Hex(keyfile_seed)),
+        ("kf-xmlv1", KeyfileKind::XmlV1(keyfile_seed)),
+        ("kf-xmlv2", KeyfileKind::XmlV2(keyfile_seed)),
+    ];
+    for (kf_l, kf) in &kinds {
+        let label: &'static str =
+            Box::leak(format!("aes256+gz+inner-chacha20+argon2d+{kf_l}").into_boxed_str());
+        combos.push(Combo {
+            label,
+            outer_cipher: OuterCipherConfig::AES256,
+            compression: CompressionConfig::GZip,
+            inner_cipher: InnerCipherConfig::ChaCha20,
+            kdf: fast_argon2(),
+            master_key: MasterKey::Keyfile(kf.clone()),
+        });
+    }
+
+    combos.push(Combo {
+        label: "aes256+gz+inner-chacha20+argon2d+pw+kf-raw32",
+        outer_cipher: OuterCipherConfig::AES256,
+        compression: CompressionConfig::GZip,
+        inner_cipher: InnerCipherConfig::ChaCha20,
+        kdf: fast_argon2(),
+        master_key: MasterKey::PasswordAndKeyfile(DEMO_PASSWORD, KeyfileKind::Raw32(keyfile_seed)),
+    });
+
+    combos
+}
+
+pub fn combo_by_label(label: &str) -> Combo {
+    round_trip_combos()
+        .into_iter()
+        .find(|c| c.label == label)
+        .unwrap_or_else(|| panic!("combo {label} not in matrix"))
+}
+
+pub fn baseline_combo() -> Combo {
+    combo_by_label("aes256+gz+inner-chacha20+argon2d")
+}
+
+pub fn fast_combo() -> Combo {
+    combo_by_label("aes256+none+inner-chacha20+aeskdf")
+}
+
+pub fn config_and_key_for(combo: &Combo) -> (DatabaseConfig, DatabaseKey) {
+    let mut cfg = DatabaseConfig::default();
+    cfg.version = DatabaseVersion::KDB4(0);
+    cfg.outer_cipher_config = combo.outer_cipher.clone();
+    cfg.compression_config = combo.compression.clone();
+    cfg.inner_cipher_config = combo.inner_cipher.clone();
+    cfg.kdf_config = combo.kdf.clone();
+    cfg.public_custom_data = None;
+    let key = match &combo.master_key {
+        MasterKey::Password(p) => DatabaseKey::new().with_password(p),
+        MasterKey::Keyfile(k) => {
+            let bytes = k.to_bytes();
+            DatabaseKey::new()
+                .with_keyfile(&mut Cursor::new(bytes))
+                .expect("keyfile read")
+        }
+        MasterKey::PasswordAndKeyfile(p, k) => {
+            let bytes = k.to_bytes();
+            DatabaseKey::new()
+                .with_password(p)
+                .with_keyfile(&mut Cursor::new(bytes))
+                .expect("keyfile read")
+        }
+    };
+    (cfg, key)
+}
+
+pub fn rich_database(config: DatabaseConfig) -> Database {
+    use chrono::NaiveDate;
+
+    let mut db = Database::with_config(config);
+    db.meta.generator = Some("keepass-spec-tests".to_string());
+    db.meta.database_name = Some("rich-fixture".to_string());
+    db.meta.database_description = Some("test fixture".to_string());
+
+    db.meta.custom_data.insert(
+        "fixture.kind".to_string(),
+        CustomDataItem {
+            value: Some(CustomDataValue::String("rich".to_string())),
+            last_modification_time: None,
+        },
+    );
+
+    let mut first_entry_id = None;
+    for i in 0..10 {
+        let mut root = db.root_mut();
+        let mut e = root.add_entry();
+        e.set_unprotected("Title", format!("entry-{i:02}"));
+        e.set_unprotected("UserName", format!("user-{i:02}"));
+        e.set_protected("Password", format!("pw-{i:02}"));
+        e.set_unprotected("URL", format!("https://example.invalid/{i}"));
+        e.set_unprotected(format!("custom.unprotected.{i}"), format!("plain-{i}"));
+        e.set_protected(format!("custom.protected.{i}"), format!("secret-{i}"));
+        if i % 2 == 0 {
+            e.tags = vec![format!("tag-{i}"), "fixture".to_string()];
+            e.times.expires = Some(true);
+            e.times.expiry = Some(
+                NaiveDate::from_ymd_opt(2099, 12, 31)
+                    .unwrap()
+                    .and_hms_opt(23, 59, 59)
+                    .unwrap(),
+            );
+        }
+        e.custom_data.insert(
+            format!("entry.cd.{i}"),
+            CustomDataItem {
+                value: Some(CustomDataValue::String(format!("cd-{i}"))),
+                last_modification_time: None,
+            },
+        );
+        if i == 0 {
+            first_entry_id = Some(e.id());
+        }
+    }
+
+    let bin_uuid = {
+        let mut root = db.root_mut();
+        let mut rec_bin = root.add_group();
+        rec_bin.name = "Recycle Bin".to_string();
+        let bin_id = rec_bin.id();
+        let mut rec_entry = rec_bin.add_entry();
+        rec_entry.set_unprotected("Title", "deleted-entry");
+        bin_id.uuid()
+    };
+    db.meta.recyclebin_enabled = Some(true);
+    db.meta.recyclebin_uuid = Some(bin_uuid);
+
+    let first_id = first_entry_id.expect("at least one entry created");
+    let mut e = db.entry_mut(first_id).expect("first entry exists");
+    e.add_attachment("small.bin", Value::Unprotected(b"small".to_vec()));
+    let noise = {
+        let mut buf = vec![0u8; 4 * 1024];
+        let mut r = StdRng::seed_from_u64(MASTER_SEED ^ 0xA);
+        r.fill_bytes(&mut buf);
+        buf
+    };
+    e.add_attachment("noise.bin", Value::Unprotected(noise));
+    e.add_attachment(
+        "nonutf8.bin",
+        Value::Unprotected(vec![0xFF, 0xFE, 0xFD, 0x80, 0x81, 0x82, 0x00, 0x01]),
+    );
+
+    db
+}
+
+pub fn minimal_database(config: DatabaseConfig) -> Database {
+    let mut db = Database::with_config(config);
+    let mut root = db.root_mut();
+    let mut e = root.add_entry();
+    e.set_unprotected("Title", "only-entry");
+    db
+}
+
+pub fn save_to_vec(db: &Database, key: DatabaseKey) -> Vec<u8> {
+    let mut buf = Vec::new();
+    db.save(&mut buf, key).expect("save_to_vec: save failed");
+    buf
+}

--- a/tests/cross_tool.rs
+++ b/tests/cross_tool.rs
@@ -1,0 +1,64 @@
+#![forbid(unsafe_code)]
+
+mod common;
+
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use common::{baseline_combo, config_and_key_for, rich_database, DEMO_PASSWORD};
+
+fn keepassxc_cli_present() -> bool {
+    Command::new("keepassxc-cli")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn keepassxc_cli_lists_our_vault() {
+    if !keepassxc_cli_present() {
+        eprintln!("keepassxc-cli not on PATH — skipping");
+        return;
+    }
+
+    let combo = baseline_combo();
+    let (cfg, key) = config_and_key_for(&combo);
+    let db = rich_database(cfg);
+    let bytes = common::save_to_vec(&db, key);
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("fixture.kdbx");
+    std::fs::write(&path, &bytes).expect("write vault");
+
+    let mut child = Command::new("keepassxc-cli")
+        .arg("ls")
+        .arg(&path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn keepassxc-cli");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(format!("{DEMO_PASSWORD}\n").as_bytes())
+        .expect("write password");
+    let out = child.wait_with_output().expect("wait keepassxc-cli");
+    if !out.status.success() {
+        panic!(
+            "keepassxc-cli ls failed: {} stderr={}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("entry-"),
+        "keepassxc-cli output didn't list our entries: {:?}",
+        stdout
+    );
+}

--- a/tests/cross_tool.rs
+++ b/tests/cross_tool.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "save_kdbx4")]
 #![forbid(unsafe_code)]
 
 mod common;
@@ -5,29 +6,13 @@ mod common;
 use std::io::Write as _;
 use std::process::{Command, Stdio};
 
-use common::{baseline_combo, config_and_key_for, rich_database, DEMO_PASSWORD};
+use common::{baseline_combo, DEMO_PASSWORD};
 
-fn keepassxc_cli_present() -> bool {
-    Command::new("keepassxc-cli")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
-#[test]
+#[test_with::executable(keepassxc-cli)]
 fn keepassxc_cli_lists_our_vault() {
-    if !keepassxc_cli_present() {
-        eprintln!("keepassxc-cli not on PATH — skipping");
-        return;
-    }
-
     let combo = baseline_combo();
-    let (cfg, key) = config_and_key_for(&combo);
-    let db = rich_database(cfg);
-    let bytes = common::save_to_vec(&db, key);
+    let db = combo.rich_database();
+    let bytes = common::save_to_vec(&db, combo.get_key());
 
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("fixture.kdbx");

--- a/tests/keyfile_formats.rs
+++ b/tests/keyfile_formats.rs
@@ -1,0 +1,83 @@
+#![forbid(unsafe_code)]
+
+mod common;
+
+use std::io::Cursor;
+
+use common::{baseline_combo, config_and_key_for, minimal_database, KeyfileKind};
+use keepass::{Database, DatabaseKey};
+
+fn root_child_count(db: &Database) -> usize {
+    let r = db.root();
+    r.entries().count() + r.groups().count()
+}
+
+fn drive(kind: KeyfileKind, label: &str) {
+    let (cfg, _) = config_and_key_for(&baseline_combo());
+
+    let bytes = kind.to_bytes();
+    let key = DatabaseKey::new()
+        .with_keyfile(&mut Cursor::new(bytes.clone()))
+        .expect("keyfile parse");
+
+    let db = minimal_database(cfg);
+    let saved = common::save_to_vec(&db, key);
+
+    let reopen_key = DatabaseKey::new()
+        .with_keyfile(&mut Cursor::new(bytes))
+        .expect("keyfile parse 2");
+    let parsed = Database::open(&mut saved.as_slice(), reopen_key)
+        .unwrap_or_else(|e| panic!("{} reopen failed: {:?}", label, e));
+    assert_eq!(root_child_count(&parsed), root_child_count(&db));
+}
+
+#[test]
+fn keyfile_raw32_round_trip() {
+    drive(KeyfileKind::Raw32([7u8; 32]), "raw32");
+}
+
+#[test]
+fn keyfile_hex_round_trip() {
+    drive(KeyfileKind::Hex([0x42u8; 32]), "hex");
+}
+
+#[test]
+fn keyfile_xml_v1_round_trip() {
+    drive(KeyfileKind::XmlV1([0x33u8; 32]), "xml-v1");
+}
+
+#[test]
+fn keyfile_xml_v2_round_trip() {
+    drive(KeyfileKind::XmlV2([0x55u8; 32]), "xml-v2");
+}
+
+#[test]
+fn keyfile_invalid_xml_falls_back_to_hash() {
+    let (cfg, _) = config_and_key_for(&baseline_combo());
+    let garbage = b"<not><a><keyfile></a></not>".to_vec();
+    let key = DatabaseKey::new()
+        .with_keyfile(&mut Cursor::new(garbage.clone()))
+        .expect("garbage keyfile accepted");
+    let db = minimal_database(cfg);
+    let saved = common::save_to_vec(&db, key);
+    let reopen = DatabaseKey::new()
+        .with_keyfile(&mut Cursor::new(garbage))
+        .expect("garbage keyfile accepted 2");
+    let parsed = Database::open(&mut saved.as_slice(), reopen).expect("garbage keyfile reopens");
+    assert_eq!(root_child_count(&parsed), 1);
+}
+
+#[test]
+fn keyfile_empty_is_consistent() {
+    let (cfg, _) = config_and_key_for(&baseline_combo());
+    let key = DatabaseKey::new()
+        .with_keyfile(&mut Cursor::new(Vec::<u8>::new()))
+        .expect("empty keyfile accepted");
+    let db = minimal_database(cfg);
+    let saved = common::save_to_vec(&db, key);
+    let reopen = DatabaseKey::new()
+        .with_keyfile(&mut Cursor::new(Vec::<u8>::new()))
+        .expect("empty keyfile accepted");
+    let parsed = Database::open(&mut saved.as_slice(), reopen).expect("empty keyfile reopens");
+    assert_eq!(root_child_count(&parsed), 1);
+}

--- a/tests/keyfile_formats.rs
+++ b/tests/keyfile_formats.rs
@@ -1,26 +1,21 @@
+#![cfg(feature = "save_kdbx4")]
 #![forbid(unsafe_code)]
 
 mod common;
 
 use std::io::Cursor;
 
-use common::{baseline_combo, config_and_key_for, minimal_database, KeyfileKind};
+use common::{baseline_combo, KeyfileKind};
 use keepass::{Database, DatabaseKey};
 
-fn root_child_count(db: &Database) -> usize {
-    let r = db.root();
-    r.entries().count() + r.groups().count()
-}
-
 fn drive(kind: KeyfileKind, label: &str) {
-    let (cfg, _) = config_and_key_for(&baseline_combo());
-
+    let combo = baseline_combo();
     let bytes = kind.to_bytes();
     let key = DatabaseKey::new()
         .with_keyfile(&mut Cursor::new(bytes.clone()))
         .expect("keyfile parse");
 
-    let db = minimal_database(cfg);
+    let db = combo.minimal_database();
     let saved = common::save_to_vec(&db, key);
 
     let reopen_key = DatabaseKey::new()
@@ -28,7 +23,8 @@ fn drive(kind: KeyfileKind, label: &str) {
         .expect("keyfile parse 2");
     let parsed = Database::open(&mut saved.as_slice(), reopen_key)
         .unwrap_or_else(|e| panic!("{} reopen failed: {:?}", label, e));
-    assert_eq!(root_child_count(&parsed), root_child_count(&db));
+    assert_eq!(parsed.root().entries().count(), 1);
+    assert_eq!(parsed.root().groups().count(), 0);
 }
 
 #[test]
@@ -53,31 +49,33 @@ fn keyfile_xml_v2_round_trip() {
 
 #[test]
 fn keyfile_invalid_xml_falls_back_to_hash() {
-    let (cfg, _) = config_and_key_for(&baseline_combo());
+    let combo = baseline_combo();
     let garbage = b"<not><a><keyfile></a></not>".to_vec();
     let key = DatabaseKey::new()
         .with_keyfile(&mut Cursor::new(garbage.clone()))
         .expect("garbage keyfile accepted");
-    let db = minimal_database(cfg);
+    let db = combo.minimal_database();
     let saved = common::save_to_vec(&db, key);
     let reopen = DatabaseKey::new()
         .with_keyfile(&mut Cursor::new(garbage))
         .expect("garbage keyfile accepted 2");
     let parsed = Database::open(&mut saved.as_slice(), reopen).expect("garbage keyfile reopens");
-    assert_eq!(root_child_count(&parsed), 1);
+    assert_eq!(parsed.root().entries().count(), 1);
+    assert_eq!(parsed.root().groups().count(), 0);
 }
 
 #[test]
 fn keyfile_empty_is_consistent() {
-    let (cfg, _) = config_and_key_for(&baseline_combo());
+    let combo = baseline_combo();
     let key = DatabaseKey::new()
         .with_keyfile(&mut Cursor::new(Vec::<u8>::new()))
         .expect("empty keyfile accepted");
-    let db = minimal_database(cfg);
+    let db = combo.minimal_database();
     let saved = common::save_to_vec(&db, key);
     let reopen = DatabaseKey::new()
         .with_keyfile(&mut Cursor::new(Vec::<u8>::new()))
         .expect("empty keyfile accepted");
     let parsed = Database::open(&mut saved.as_slice(), reopen).expect("empty keyfile reopens");
-    assert_eq!(root_child_count(&parsed), 1);
+    assert_eq!(parsed.root().entries().count(), 1);
+    assert_eq!(parsed.root().groups().count(), 0);
 }

--- a/tests/spec_round_trip.rs
+++ b/tests/spec_round_trip.rs
@@ -1,0 +1,152 @@
+#![forbid(unsafe_code)]
+
+mod common;
+
+use common::{baseline_combo, config_and_key_for, minimal_database, rich_database, round_trip_combos, Combo};
+use keepass::{db::Value, Database};
+
+fn opening_key_for(combo: &Combo) -> keepass::DatabaseKey {
+    config_and_key_for(combo).1
+}
+
+fn root_child_count(db: &Database) -> usize {
+    let root = db.root();
+    root.entries().count() + root.groups().count()
+}
+
+#[test]
+fn matrix_round_trip_minimal_database() {
+    for combo in &round_trip_combos() {
+        let (cfg, key) = config_and_key_for(combo);
+        let db = minimal_database(cfg);
+        let bytes = common::save_to_vec(&db, key);
+        assert!(
+            bytes.len() > 32,
+            "combo {} produced suspiciously small output ({} bytes)",
+            combo.label,
+            bytes.len()
+        );
+        assert_eq!(
+            &bytes[..4],
+            &[0x03, 0xd9, 0xa2, 0x9a],
+            "combo {} missing kdbx magic",
+            combo.label
+        );
+        let parsed = Database::open(&mut bytes.as_slice(), opening_key_for(combo))
+            .unwrap_or_else(|e| panic!("combo {} reopen failed: {:?}", combo.label, e));
+        assert_eq!(root_child_count(&parsed), root_child_count(&db));
+    }
+}
+
+#[test]
+fn matrix_round_trip_rich_database_subset() {
+    let combos = round_trip_combos();
+    let subset: Vec<&Combo> = combos
+        .iter()
+        .filter(|c| {
+            c.label.contains("aes256+gz+inner-chacha20+argon2d")
+                || c.label.contains("chacha20+gz+inner-chacha20+argon2id")
+                || c.label.contains("aes256+none+inner-salsa20+aeskdf")
+        })
+        .collect();
+    for combo in &subset {
+        let (cfg, key) = config_and_key_for(combo);
+        let db = rich_database(cfg);
+        let bytes = common::save_to_vec(&db, key);
+
+        let parsed = Database::open(&mut bytes.as_slice(), opening_key_for(combo))
+            .unwrap_or_else(|e| panic!("combo {} reopen failed: {:?}", combo.label, e));
+
+        assert_eq!(
+            parsed.root().entries().count(),
+            10,
+            "{} root entry count",
+            combo.label
+        );
+        assert_eq!(
+            parsed.root().groups().count(),
+            1,
+            "{} root group count",
+            combo.label
+        );
+        assert_eq!(
+            parsed.num_attachments(),
+            3,
+            "{} num_attachments mismatch",
+            combo.label
+        );
+
+        let root = parsed.root();
+        let entry = root
+            .entries()
+            .find(|e| e.attachment_by_name("small.bin").is_some())
+            .unwrap_or_else(|| panic!("{}: no entry holds small.bin", combo.label));
+        let small = entry.attachment_by_name("small.bin").expect("small.bin present");
+        assert_eq!(small.data.get().as_slice(), b"small", "{} small.bin", combo.label);
+        let noise = entry.attachment_by_name("noise.bin").expect("noise.bin present");
+        assert_eq!(noise.data.get().len(), 4096, "{} noise.bin len", combo.label);
+        let nonutf8 = entry
+            .attachment_by_name("nonutf8.bin")
+            .expect("nonutf8.bin present");
+        assert_eq!(
+            nonutf8.data.get().as_slice(),
+            &[0xFF, 0xFE, 0xFD, 0x80, 0x81, 0x82, 0x00, 0x01],
+            "{} nonutf8 bytes",
+            combo.label
+        );
+
+        let names: Vec<String> = entry.attachments_named().map(|(n, _)| n.to_string()).collect();
+        for n in ["small.bin", "noise.bin", "nonutf8.bin"] {
+            assert!(names.contains(&n.to_string()), "{} {} name", combo.label, n);
+        }
+
+        assert!(parsed.meta.custom_data.contains_key("fixture.kind"));
+        assert_eq!(parsed.meta.recyclebin_enabled, Some(true));
+    }
+}
+
+#[test]
+fn second_save_is_self_consistent() {
+    let combo = baseline_combo();
+    let (cfg, key) = config_and_key_for(&combo);
+    let db = rich_database(cfg);
+    let bytes_a = common::save_to_vec(&db, key);
+    let parsed_a = Database::open(&mut bytes_a.as_slice(), opening_key_for(&combo)).unwrap();
+
+    let bytes_b = common::save_to_vec(&parsed_a, opening_key_for(&combo));
+    let parsed_b = Database::open(&mut bytes_b.as_slice(), opening_key_for(&combo)).unwrap();
+
+    assert_eq!(root_child_count(&parsed_a), root_child_count(&parsed_b));
+    assert_eq!(parsed_a.num_attachments(), parsed_b.num_attachments());
+    assert_eq!(parsed_a.meta.database_name, parsed_b.meta.database_name);
+}
+
+#[test]
+fn protected_field_decrypts_after_round_trip() {
+    let combo = baseline_combo();
+    let (cfg, key) = config_and_key_for(&combo);
+    let db = rich_database(cfg);
+    let bytes = common::save_to_vec(&db, key);
+    let parsed = Database::open(&mut bytes.as_slice(), opening_key_for(&combo)).unwrap();
+
+    let root = parsed.root();
+    let entry = root
+        .entries()
+        .find(|e| e.get_title().is_some_and(|t| t.starts_with("entry-")))
+        .expect("at least one entry-NN");
+    let pw = entry.get("Password").expect("password is decryptable");
+    assert!(pw.starts_with("pw-"));
+
+    let mut found = false;
+    for e in parsed.root().entries() {
+        for (k, v) in &e.fields {
+            if k.starts_with("custom.protected.") {
+                if let Value::Protected(_) = v {
+                    found = true;
+                    break;
+                }
+            }
+        }
+    }
+    assert!(found, "no Protected custom field round-tripped");
+}

--- a/tests/spec_round_trip.rs
+++ b/tests/spec_round_trip.rs
@@ -1,25 +1,16 @@
+#![cfg(feature = "save_kdbx4")]
 #![forbid(unsafe_code)]
 
 mod common;
 
-use common::{baseline_combo, config_and_key_for, minimal_database, rich_database, round_trip_combos, Combo};
+use common::{baseline_combo, round_trip_combos, Combo};
 use keepass::{db::Value, Database};
-
-fn opening_key_for(combo: &Combo) -> keepass::DatabaseKey {
-    config_and_key_for(combo).1
-}
-
-fn root_child_count(db: &Database) -> usize {
-    let root = db.root();
-    root.entries().count() + root.groups().count()
-}
 
 #[test]
 fn matrix_round_trip_minimal_database() {
     for combo in &round_trip_combos() {
-        let (cfg, key) = config_and_key_for(combo);
-        let db = minimal_database(cfg);
-        let bytes = common::save_to_vec(&db, key);
+        let db = combo.minimal_database();
+        let bytes = common::save_to_vec(&db, combo.get_key());
         assert!(
             bytes.len() > 32,
             "combo {} produced suspiciously small output ({} bytes)",
@@ -32,9 +23,9 @@ fn matrix_round_trip_minimal_database() {
             "combo {} missing kdbx magic",
             combo.label
         );
-        let parsed = Database::open(&mut bytes.as_slice(), opening_key_for(combo))
+        let parsed = Database::open(&mut bytes.as_slice(), combo.get_key())
             .unwrap_or_else(|e| panic!("combo {} reopen failed: {:?}", combo.label, e));
-        assert_eq!(root_child_count(&parsed), root_child_count(&db));
+        assert_eq!(parsed, db, "combo {} round-trip mismatch", combo.label);
     }
 }
 
@@ -50,11 +41,10 @@ fn matrix_round_trip_rich_database_subset() {
         })
         .collect();
     for combo in &subset {
-        let (cfg, key) = config_and_key_for(combo);
-        let db = rich_database(cfg);
-        let bytes = common::save_to_vec(&db, key);
+        let db = combo.rich_database();
+        let bytes = common::save_to_vec(&db, combo.get_key());
 
-        let parsed = Database::open(&mut bytes.as_slice(), opening_key_for(combo))
+        let parsed = Database::open(&mut bytes.as_slice(), combo.get_key())
             .unwrap_or_else(|e| panic!("combo {} reopen failed: {:?}", combo.label, e));
 
         assert_eq!(
@@ -108,26 +98,22 @@ fn matrix_round_trip_rich_database_subset() {
 #[test]
 fn second_save_is_self_consistent() {
     let combo = baseline_combo();
-    let (cfg, key) = config_and_key_for(&combo);
-    let db = rich_database(cfg);
-    let bytes_a = common::save_to_vec(&db, key);
-    let parsed_a = Database::open(&mut bytes_a.as_slice(), opening_key_for(&combo)).unwrap();
+    let db = combo.rich_database();
+    let bytes_a = common::save_to_vec(&db, combo.get_key());
+    let parsed_a = Database::open(&mut bytes_a.as_slice(), combo.get_key()).unwrap();
 
-    let bytes_b = common::save_to_vec(&parsed_a, opening_key_for(&combo));
-    let parsed_b = Database::open(&mut bytes_b.as_slice(), opening_key_for(&combo)).unwrap();
+    let bytes_b = common::save_to_vec(&parsed_a, combo.get_key());
+    let parsed_b = Database::open(&mut bytes_b.as_slice(), combo.get_key()).unwrap();
 
-    assert_eq!(root_child_count(&parsed_a), root_child_count(&parsed_b));
-    assert_eq!(parsed_a.num_attachments(), parsed_b.num_attachments());
-    assert_eq!(parsed_a.meta.database_name, parsed_b.meta.database_name);
+    assert_eq!(parsed_a, parsed_b);
 }
 
 #[test]
 fn protected_field_decrypts_after_round_trip() {
     let combo = baseline_combo();
-    let (cfg, key) = config_and_key_for(&combo);
-    let db = rich_database(cfg);
-    let bytes = common::save_to_vec(&db, key);
-    let parsed = Database::open(&mut bytes.as_slice(), opening_key_for(&combo)).unwrap();
+    let db = combo.rich_database();
+    let bytes = common::save_to_vec(&db, combo.get_key());
+    let parsed = Database::open(&mut bytes.as_slice(), combo.get_key()).unwrap();
 
     let root = parsed.root();
     let entry = root


### PR DESCRIPTION
## Summary

Adds a kdbx4 spec test suite under `tests/`: round-trip across the cipher × KDF × compression × inner-stream × keyfile matrix, parser-error coverage for malformed inputs, keyfile format coverage (raw/hex/xml-v1/xml-v2), and binary-attachment round-tripping.

Fixtures are generated at test time from a seeded RNG — no on-disk corpus. All KDFs run with `iterations=1` per [CONTRIBUTING.md](../CONTRIBUTING.md). The suite is gated behind the `save_kdbx4` feature.

`tempfile`, `rand`, and `test-with` are added as native-only dev-dependencies.

## Test plan

- [x] `cargo test --features save_kdbx4 --test spec_round_trip --test broken_files --test keyfile_formats --test binary_pool --test cross_tool` — all pass locally.
- [x] `cargo test --no-default-features` — clean compile under cfg gate.

## Review feedback addressed

### Round 1 (33a5c50)

| Reviewer | Path:line | Verdict | Fix |
|---|---|---|---|
| sseemayer | tests/common/mod.rs:305 | adopt | `config_and_key_for` split into `Combo::get_config()` + `Combo::get_key()`; `minimal_database` / `rich_database` moved to methods on `Combo` |
| sseemayer | tests/broken_files.rs:25 | partial | Dropped `catch_unwind`. Deterministic mutations match specific variants (`VersionParse(InvalidKDBXIdentifier/InvalidKDBXVersion)`, `Key(IncorrectKey)`); ambiguous ones still use `assert!(res.is_err())` |
| sseemayer | tests/cross_tool.rs:25 | adopt | `test-with` (executable feature only) added as native dev-dep; test gated with `#[test_with::executable(keepassxc-cli)]` |
| sseemayer | tests/keyfile_formats.rs:67 | adopt | `root_child_count` helper removed; replaced with `parsed.root().entries().count()` / `groups().count()` |
| sseemayer | tests/spec_round_trip.rs:37 | adopt | Minimal-matrix and `second_save_is_self_consistent` now use `assert_eq!(parsed, db)`. Rich-matrix keeps per-field asserts so failures name the offending field+combo |
| sseemayer | top-level (rebase / feature-gate) | adopt | Rebased on master (PR #325); `save_to_vec` and all five test files gated behind `save_kdbx4` |
| sseemayer | top-level (`keepass::test::fixtures`) | discussion | Replied — proposed landing this PR as test-only first, then a follow-up that re-exports `Combo` + builders under a `test-fixtures` cargo feature |
