### PR TITLE
fix: keepass and keepassxc compatibility

### DIFF
--- a/src/format/xml_db/entry.rs
+++ b/src/format/xml_db/entry.rs
@@ -22,22 +22,32 @@ pub struct Entry {
     #[serde(rename = "UUID")]
     pub uuid: UUID,
 
-    #[serde(default, rename = "IconID", with = "cs_opt_fromstr")]
+    #[serde(
+        default,
+        rename = "IconID",
+        with = "cs_opt_fromstr",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub icon_id: Option<usize>,
 
     #[serde(default, rename = "CustomIconUUID", skip_serializing_if = "Option::is_none")]
     pub custom_icon_uuid: Option<UUID>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub foreground_color: Option<Color>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub background_color: Option<Color>,
 
-    #[serde(default, rename = "OverrideURL", with = "cs_opt_string")]
+    #[serde(
+        default,
+        rename = "OverrideURL",
+        with = "cs_opt_string",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub override_url: Option<String>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub tags: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -237,7 +247,12 @@ pub struct StringValue {
     #[serde(default, rename = "@Protected", with = "cs_bool")]
     protected: bool,
 
-    #[serde(default, rename = "$value", with = "cs_opt_string")]
+    #[serde(
+        default,
+        rename = "$value",
+        with = "cs_opt_string",
+        skip_serializing_if = "Option::is_none"
+    )]
     value: Option<String>,
 }
 
@@ -290,10 +305,10 @@ pub struct AutoType {
     #[serde(default, with = "cs_bool")]
     pub enabled: bool,
 
-    #[serde(default, with = "cs_opt_intbool")]
+    #[serde(default, with = "cs_opt_intbool", skip_serializing_if = "Option::is_none")]
     pub data_transfer_obfuscation: Option<bool>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub default_sequence: Option<String>,
 
     #[serde(rename = "Association", default)]

--- a/src/format/xml_db/group.rs
+++ b/src/format/xml_db/group.rs
@@ -23,22 +23,27 @@ pub struct Group {
 
     pub name: String,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
 
-    #[serde(default, rename = "IconID", with = "cs_opt_fromstr")]
+    #[serde(
+        default,
+        rename = "IconID",
+        with = "cs_opt_fromstr",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub icon_id: Option<usize>,
 
     #[serde(default, rename = "CustomIconUUID", skip_serializing_if = "Option::is_none")]
     pub custom_icon_uuid: Option<UUID>,
 
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub times: Option<Times>,
 
-    #[serde(default, with = "cs_opt_bool")]
+    #[serde(default, with = "cs_opt_bool", skip_serializing_if = "Option::is_none")]
     pub is_expanded: Option<bool>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub default_auto_type_sequence: Option<String>,
 
     #[serde(default, with = "cs_opt_bool")]
@@ -47,7 +52,7 @@ pub struct Group {
     #[serde(default, with = "cs_opt_bool")]
     pub enable_searching: Option<bool>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub last_top_visible_entry: Option<UUID>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/format/xml_db/meta.rs
+++ b/src/format/xml_db/meta.rs
@@ -18,40 +18,50 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Meta {
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     generator: Option<String>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     database_name: Option<String>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     database_name_changed: Option<Timestamp>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     database_description: Option<String>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     database_description_changed: Option<Timestamp>,
 
-    #[serde(default, with = "cs_opt_string", rename = "DefaultUserName")]
+    #[serde(
+        default,
+        with = "cs_opt_string",
+        rename = "DefaultUserName",
+        skip_serializing_if = "Option::is_none"
+    )]
     default_username: Option<String>,
 
-    #[serde(default, with = "cs_opt_string", rename = "DefaultUserNameChanged")]
+    #[serde(
+        default,
+        with = "cs_opt_string",
+        rename = "DefaultUserNameChanged",
+        skip_serializing_if = "Option::is_none"
+    )]
     default_username_changed: Option<Timestamp>,
 
-    #[serde(default, with = "cs_opt_fromstr")]
+    #[serde(default, with = "cs_opt_fromstr", skip_serializing_if = "Option::is_none")]
     maintenance_history_days: Option<usize>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     master_key_changed: Option<Timestamp>,
 
-    #[serde(default, with = "cs_opt_fromstr")]
+    #[serde(default, with = "cs_opt_fromstr", skip_serializing_if = "Option::is_none")]
     master_key_change_rec: Option<isize>,
 
-    #[serde(default, with = "cs_opt_fromstr")]
+    #[serde(default, with = "cs_opt_fromstr", skip_serializing_if = "Option::is_none")]
     master_key_change_force: Option<isize>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -60,34 +70,39 @@ pub struct Meta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_icons: Option<CustomIcons>,
 
-    #[serde(default, with = "cs_opt_bool")]
+    #[serde(default, with = "cs_opt_bool", skip_serializing_if = "Option::is_none")]
     recycle_bin_enabled: Option<bool>,
 
-    #[serde(default, rename = "RecycleBinUUID", with = "cs_opt_string")]
+    #[serde(
+        default,
+        rename = "RecycleBinUUID",
+        with = "cs_opt_string",
+        skip_serializing_if = "Option::is_none"
+    )]
     recycle_bin_uuid: Option<UUID>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     recycle_bin_changed: Option<Timestamp>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     entry_templates_group: Option<UUID>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     entry_templates_group_changed: Option<Timestamp>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     last_selected_group: Option<UUID>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     last_top_visible_group: Option<UUID>,
 
-    #[serde(default, with = "cs_opt_fromstr")]
+    #[serde(default, with = "cs_opt_fromstr", skip_serializing_if = "Option::is_none")]
     history_max_items: Option<isize>,
 
-    #[serde(default, with = "cs_opt_fromstr")]
+    #[serde(default, with = "cs_opt_fromstr", skip_serializing_if = "Option::is_none")]
     history_max_size: Option<isize>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     settings_changed: Option<Timestamp>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -327,7 +342,7 @@ struct CustomDataItem {
     key: String,
     value: CustomDataValue,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     last_modification_time: Option<Timestamp>,
 }
 
@@ -498,7 +513,7 @@ mod tests {
 
         assert_eq!(
             serialized,
-            "<CustomData><Item><Key>example_key</Key><Value>example_value</Value><LastModificationTime>cKSw3A4AAAA=</LastModificationTime></Item><Item><Key>binary_key</Key><Value>AQIDBAU=</Value><LastModificationTime/></Item></CustomData>"
+            "<CustomData><Item><Key>example_key</Key><Value>example_value</Value><LastModificationTime>cKSw3A4AAAA=</LastModificationTime></Item><Item><Key>binary_key</Key><Value>AQIDBAU=</Value></Item></CustomData>"
         );
         assert!(serialized.contains("<Key>example_key</Key>"));
         assert!(serialized.contains("<Value>example_value</Value>"));

--- a/src/format/xml_db/times.rs
+++ b/src/format/xml_db/times.rs
@@ -8,21 +8,21 @@ use crate::format::xml_db::{
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Times {
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub creation_time: Option<Timestamp>,
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub last_modification_time: Option<Timestamp>,
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub last_access_time: Option<Timestamp>,
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub expiry_time: Option<Timestamp>,
 
-    #[serde(default, with = "cs_opt_bool")]
+    #[serde(default, with = "cs_opt_bool", skip_serializing_if = "Option::is_none")]
     pub expires: Option<bool>,
-    #[serde(default, with = "cs_opt_fromstr")]
+    #[serde(default, with = "cs_opt_fromstr", skip_serializing_if = "Option::is_none")]
     pub usage_count: Option<usize>,
 
-    #[serde(default, with = "cs_opt_string")]
+    #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub location_changed: Option<Timestamp>,
 }
 

--- a/src/format/xml_db/times.rs
+++ b/src/format/xml_db/times.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::format::xml_db::{
     custom_serde::{cs_opt_bool, cs_opt_fromstr, cs_opt_string},
-    timestamp::{Timestamp, TimestampMode},
+    timestamp::Timestamp,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -42,15 +42,12 @@ impl From<Times> for crate::db::Times {
 
 impl From<crate::db::Times> for Times {
     fn from(t: crate::db::Times) -> Self {
-        // NOTE: we could store this in the Times struct to improve round-tripping
-        let mode = TimestampMode::Base64;
-
         Times {
-            creation_time: t.creation.map(|time| Timestamp { mode, time }),
-            last_modification_time: t.last_modification.map(|time| Timestamp { mode, time }),
-            last_access_time: t.last_access.map(|time| Timestamp { mode, time }),
-            expiry_time: t.expiry.map(|time| Timestamp { mode, time }),
-            location_changed: t.location_changed.map(|time| Timestamp { mode, time }),
+            creation_time: t.creation.map(|time| time.into()),
+            last_modification_time: t.last_modification.map(|time| time.into()),
+            last_access_time: t.last_access.map(|time| time.into()),
+            expiry_time: t.expiry.map(|time| time.into()),
+            location_changed: t.location_changed.map(|time| time.into()),
             expires: t.expires,
             usage_count: t.usage_count,
         }

--- a/src/format/xml_db/times.rs
+++ b/src/format/xml_db/times.rs
@@ -42,9 +42,8 @@ impl From<Times> for crate::db::Times {
 
 impl From<crate::db::Times> for Times {
     fn from(t: crate::db::Times) -> Self {
-        // Use ISO 8601 format for all timestamps
         // NOTE: we could store this in the Times struct to improve round-tripping
-        let mode = TimestampMode::Iso8601;
+        let mode = TimestampMode::Base64;
 
         Times {
             creation_time: t.creation.map(|time| Timestamp { mode, time }),

--- a/src/format/xml_db/timestamp.rs
+++ b/src/format/xml_db/timestamp.rs
@@ -45,9 +45,8 @@ impl From<Timestamp> for NaiveDateTime {
 
 impl From<NaiveDateTime> for Timestamp {
     fn from(t: NaiveDateTime) -> Self {
-        // NOTE: always use ISO8601 for serialization. We could remember the original format to
-        // have more faithful round-tripping
-        Timestamp::new_iso8601(t)
+        // always use base64 for serialization since that seems to be most compatible with keepass
+        Timestamp::new_base64(t)
     }
 }
 


### PR DESCRIPTION
fixes #324

the new XML serialization code emitted empty optional fields that would lead to parse errors with keepass and keepassxc. Also, keepass seems to accept only base64-encoded timestamps.