### PR TITLE
fix: use Base64 timestamps for KeePass compatibility

### DIFF
--- a/src/format/xml_db/times.rs
+++ b/src/format/xml_db/times.rs
@@ -42,9 +42,8 @@ impl From<Times> for crate::db::Times {
 
 impl From<crate::db::Times> for Times {
     fn from(t: crate::db::Times) -> Self {
-        // Use ISO 8601 format for all timestamps
         // NOTE: we could store this in the Times struct to improve round-tripping
-        let mode = TimestampMode::Iso8601;
+        let mode = TimestampMode::Base64;
 
         Times {
             creation_time: t.creation.map(|time| Timestamp { mode, time }),


### PR DESCRIPTION
Builds on #325  which fixes KeePassXC compatibility.
This additional change fixes compatibility with KeePass itself, which requires timestamps in KDBX4 to be Base64 encoded integers rather than ISO8601 strings. Without this, KeePass rejects the file after password entry with a parse error.
Tested against both KeePass and KeePassXC.