### PR TITLE
fix: centralize XML tag serialization

### DIFF
--- a/src/format/xml_db/entry.rs
+++ b/src/format/xml_db/entry.rs
@@ -11,6 +11,7 @@ use crate::{
     format::xml_db::{
         custom_serde::{cs_bool, cs_opt_bool, cs_opt_fromstr, cs_opt_intbool, cs_opt_string},
         meta::CustomData,
+        tags::{join_tags, split_tags},
         times::Times,
         UUID,
     },
@@ -95,10 +96,7 @@ impl Entry {
         target.foreground_color = self.foreground_color;
         target.background_color = self.background_color;
         target.override_url = self.override_url;
-        target.tags = self
-            .tags
-            .map(|t| t.split(',').map(|s| s.to_string()).collect())
-            .unwrap_or_default();
+        target.tags = self.tags.as_deref().map(split_tags).unwrap_or_default();
 
         target.times = self.times.map(|t| t.into()).unwrap_or_default();
 
@@ -221,7 +219,7 @@ impl Entry {
             foreground_color: db.foreground_color.clone(),
             background_color: db.background_color.clone(),
             override_url: db.override_url.clone(),
-            tags: db.tags.iter().cloned().reduce(|a, b| format!("{a},{b}")),
+            tags: join_tags(&db.tags),
             times: Some(db.times.clone().into()),
             string_fields,
             binary_fields,

--- a/src/format/xml_db/entry.rs
+++ b/src/format/xml_db/entry.rs
@@ -5,13 +5,15 @@ use thiserror::Error;
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "save_kdbx4")]
+use crate::format::xml_db::tags::join_tags;
 use crate::{
     crypt::{ciphers::Cipher, CryptographyError},
     db::{AttachmentId, Color, EntryId, GroupId},
     format::xml_db::{
         custom_serde::{cs_bool, cs_opt_bool, cs_opt_fromstr, cs_opt_intbool, cs_opt_string},
         meta::CustomData,
-        tags::{join_tags, split_tags},
+        tags::split_tags,
         times::Times,
         UUID,
     },

--- a/src/format/xml_db/group.rs
+++ b/src/format/xml_db/group.rs
@@ -4,13 +4,15 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "save_kdbx4")]
 use crate::crypt::CryptographyError;
+#[cfg(feature = "save_kdbx4")]
+use crate::format::xml_db::tags::join_tags;
 use crate::{
     crypt::ciphers::Cipher,
     db::{EntryId, GroupId},
     format::xml_db::{
         custom_serde::{cs_opt_bool, cs_opt_fromstr, cs_opt_string},
         entry::{Entry, UnprotectError},
-        tags::{join_tags, split_tags},
+        tags::split_tags,
         times::Times,
         UUID,
     },

--- a/src/format/xml_db/group.rs
+++ b/src/format/xml_db/group.rs
@@ -10,6 +10,7 @@ use crate::{
     format::xml_db::{
         custom_serde::{cs_opt_bool, cs_opt_fromstr, cs_opt_string},
         entry::{Entry, UnprotectError},
+        tags::{join_tags, split_tags},
         times::Times,
         UUID,
     },
@@ -84,10 +85,7 @@ impl Group {
     ) -> Result<(), UnprotectError> {
         target.name = self.name;
         target.notes = self.notes;
-        target.tags = self
-            .tags
-            .map(|t| t.split(';').map(|s| s.trim().to_string()).collect())
-            .unwrap_or_default();
+        target.tags = self.tags.as_deref().map(split_tags).unwrap_or_default();
 
         target.icon = if let Some(ci) = self.custom_icon_uuid.and_then(|ci| {
             let icon_id = crate::db::CustomIconId::from_uuid(ci.0);
@@ -158,7 +156,7 @@ impl Group {
             uuid: UUID(source.id().uuid()),
             name: source.name.clone(),
             notes: source.notes.clone(),
-            tags: source.tags.join(";").into(),
+            tags: join_tags(&source.tags),
             icon_id,
             custom_icon_uuid,
             times: Some(source.times.clone().into()),

--- a/src/format/xml_db/mod.rs
+++ b/src/format/xml_db/mod.rs
@@ -9,6 +9,7 @@ pub mod custom_serde;
 pub mod entry;
 pub mod group;
 pub mod meta;
+pub mod tags;
 pub mod times;
 pub mod timestamp;
 

--- a/src/format/xml_db/tags.rs
+++ b/src/format/xml_db/tags.rs
@@ -5,6 +5,7 @@
 //! read. Centralizing this here keeps entry and group behavior in lockstep.
 
 /// Canonical tag delimiter used when writing tags into the KeePass XML.
+#[cfg(feature = "save_kdbx4")]
 pub const TAG_DELIMITER: &str = ";";
 
 /// Delimiters accepted when parsing a `<Tags>` element value.
@@ -21,6 +22,7 @@ pub fn split_tags(raw: &str) -> Vec<String> {
 }
 
 /// Render a list of tags as a `<Tags>` element value, or `None` if there are no tags.
+#[cfg(feature = "save_kdbx4")]
 pub fn join_tags(tags: &[String]) -> Option<String> {
     if tags.is_empty() {
         None
@@ -58,17 +60,20 @@ mod tests {
         assert_eq!(split_tags(" a ; ; b ,, c "), vec!["a", "", "b", "", "c"]);
     }
 
+    #[cfg(feature = "save_kdbx4")]
     #[test]
     fn join_empty_returns_none() {
         let tags: Vec<String> = Vec::new();
         assert_eq!(join_tags(&tags), None);
     }
 
+    #[cfg(feature = "save_kdbx4")]
     #[test]
     fn join_single_tag_has_no_delimiter() {
         assert_eq!(join_tags(&["only".into()]), Some("only".into()));
     }
 
+    #[cfg(feature = "save_kdbx4")]
     #[test]
     fn join_uses_canonical_delimiter() {
         assert_eq!(
@@ -77,6 +82,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "save_kdbx4")]
     #[test]
     fn round_trip_canonical_form_is_stable() {
         let tags = vec!["alpha".to_string(), "beta".to_string()];

--- a/src/format/xml_db/tags.rs
+++ b/src/format/xml_db/tags.rs
@@ -1,0 +1,86 @@
+//! Shared (de)serialization of the `<Tags>` element used by both entry and group XML.
+//!
+//! KeePass stores tags as a delimited string. The canonical delimiter used by KeePass
+//! when writing the XML is `;`, but both KeePass and KeePassXC also accept `,` on
+//! read. Centralizing this here keeps entry and group behavior in lockstep.
+
+/// Canonical tag delimiter used when writing tags into the KeePass XML.
+pub const TAG_DELIMITER: &str = ";";
+
+/// Delimiters accepted when parsing a `<Tags>` element value.
+pub const TAG_DELIMITERS: &str = ";,";
+
+/// Parse a `<Tags>` element value into a list of tags.
+///
+/// Splits on either `;` or `,` and trims surrounding whitespace.
+pub fn split_tags(raw: &str) -> Vec<String> {
+    raw.split(|c| TAG_DELIMITERS.contains(c))
+        .map(str::trim)
+        .map(str::to_string)
+        .collect()
+}
+
+/// Render a list of tags as a `<Tags>` element value, or `None` if there are no tags.
+pub fn join_tags(tags: &[String]) -> Option<String> {
+    if tags.is_empty() {
+        None
+    } else {
+        Some(tags.join(TAG_DELIMITER))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_empty_string_preserves_empty_tag() {
+        assert_eq!(split_tags(""), vec![""]);
+    }
+
+    #[test]
+    fn split_on_semicolons() {
+        assert_eq!(split_tags("a;b;c"), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn split_on_commas_for_keepassxc_compat() {
+        assert_eq!(split_tags("keepass-rs,test"), vec!["keepass-rs", "test"]);
+    }
+
+    #[test]
+    fn split_accepts_mixed_delimiters() {
+        assert_eq!(split_tags("a;b,c"), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn split_trims_whitespace_and_preserves_empties() {
+        assert_eq!(split_tags(" a ; ; b ,, c "), vec!["a", "", "b", "", "c"]);
+    }
+
+    #[test]
+    fn join_empty_returns_none() {
+        let tags: Vec<String> = Vec::new();
+        assert_eq!(join_tags(&tags), None);
+    }
+
+    #[test]
+    fn join_single_tag_has_no_delimiter() {
+        assert_eq!(join_tags(&["only".into()]), Some("only".into()));
+    }
+
+    #[test]
+    fn join_uses_canonical_delimiter() {
+        assert_eq!(
+            join_tags(&["a".into(), "b".into(), "c".into()]),
+            Some("a;b;c".into())
+        );
+    }
+
+    #[test]
+    fn round_trip_canonical_form_is_stable() {
+        let tags = vec!["alpha".to_string(), "beta".to_string()];
+        let joined = join_tags(&tags).unwrap();
+        assert_eq!(split_tags(&joined), tags);
+    }
+}

--- a/src/format/xml_db/tags.rs
+++ b/src/format/xml_db/tags.rs
@@ -1,7 +1,7 @@
 //! Shared (de)serialization of the `<Tags>` element used by both entry and group XML.
 //!
 //! KeePass stores tags as a delimited string. The canonical delimiter used by KeePass
-//! when writing the XML is `;`, but both KeePass and KeePassXC also accept `,` on
+//! when writing the XML is `;`, but readers should also accept `,` and tab on
 //! read. Centralizing this here keeps entry and group behavior in lockstep.
 
 /// Canonical tag delimiter used when writing tags into the KeePass XML.
@@ -9,11 +9,11 @@
 pub const TAG_DELIMITER: &str = ";";
 
 /// Delimiters accepted when parsing a `<Tags>` element value.
-pub const TAG_DELIMITERS: &str = ";,";
+pub const TAG_DELIMITERS: &str = ";,\t";
 
 /// Parse a `<Tags>` element value into a list of tags.
 ///
-/// Splits on either `;` or `,` and trims surrounding whitespace.
+/// Splits on either `;`, `,`, or tab and trims surrounding whitespace.
 pub fn split_tags(raw: &str) -> Vec<String> {
     raw.split(|c| TAG_DELIMITERS.contains(c))
         .map(str::trim)
@@ -51,8 +51,13 @@ mod tests {
     }
 
     #[test]
+    fn split_on_tabs() {
+        assert_eq!(split_tags("tag1\ttag2\ttag3"), vec!["tag1", "tag2", "tag3"]);
+    }
+
+    #[test]
     fn split_accepts_mixed_delimiters() {
-        assert_eq!(split_tags("a;b,c"), vec!["a", "b", "c"]);
+        assert_eq!(split_tags("a;b,c\td"), vec!["a", "b", "c", "d"]);
     }
 
     #[test]

--- a/tests/tag_serialization.rs
+++ b/tests/tag_serialization.rs
@@ -1,0 +1,135 @@
+//! Regression tests for sseemayer/keepass-rs#338: centralized tag
+//! delimiter and (de)serialization shared between entry and group.
+//!
+//! Before the fix:
+//!   * `Entry::xml_to_db_handle` split tags on `,`.
+//!   * `Group::xml_to_db_handle` split tags on `;`.
+//!   * `Entry::db_to_xml` joined tags with `,`.
+//!   * `Group::db_to_xml` joined tags with `;`.
+//!
+//! The canonical KeePass write delimiter is `;`. KeePassXC has historically
+//! also written `,` (see `tests/resources/inner_xml_with_custom_fields.xml`
+//! and `test_db_kdbx4_with_password_aes.kdbx`), so reading must accept both.
+
+#![cfg(feature = "save_kdbx4")]
+
+use keepass::{Database, DatabaseKey};
+
+const PASSWORD: &str = "demopass";
+
+fn key() -> DatabaseKey {
+    DatabaseKey::new().with_password(PASSWORD)
+}
+
+fn build_db_with_tagged_entry_and_group(entry_tags: Vec<String>, group_tags: Vec<String>) -> Database {
+    let mut db = Database::new();
+
+    {
+        let mut root = db.root_mut();
+
+        let mut entry = root.add_entry();
+        entry.set_unprotected("Title", "tagged-entry");
+        entry.tags = entry_tags;
+
+        let mut group = root.add_group();
+        group.name = "tagged-group".to_string();
+        group.tags = group_tags;
+    }
+
+    db
+}
+
+fn save_and_get_xml(db: &Database) -> (Vec<u8>, String) {
+    let mut buf = Vec::new();
+    db.save(&mut buf, key()).expect("save db");
+
+    let xml = Database::get_xml(&mut std::io::Cursor::new(&buf), key()).expect("decrypt re-save");
+    let xml = String::from_utf8(xml).expect("xml is utf-8");
+
+    (buf, xml)
+}
+
+#[test]
+fn writer_uses_canonical_semicolon_delimiter_for_entry_and_group() {
+    let db = build_db_with_tagged_entry_and_group(
+        vec!["alpha".into(), "beta".into(), "gamma".into()],
+        vec!["one".into(), "two".into(), "three".into()],
+    );
+
+    let (_, xml) = save_and_get_xml(&db);
+
+    assert!(
+        xml.contains("<Tags>alpha;beta;gamma</Tags>"),
+        "expected entry tags joined with ';' (canonical KeePass delimiter). \
+         Before sseemayer/keepass-rs#338 the entry writer used ',' which \
+         diverged from the group writer. Got XML:\n{}",
+        xml,
+    );
+    assert!(
+        xml.contains("<Tags>one;two;three</Tags>"),
+        "expected group tags joined with ';'. Got XML:\n{}",
+        xml,
+    );
+    assert!(
+        !xml.contains("<Tags>alpha,beta,gamma</Tags>"),
+        "entry tags must not use ',' as the canonical write delimiter. \
+         Got XML:\n{}",
+        xml,
+    );
+}
+
+#[test]
+fn entry_and_group_round_trip_tags_identically() {
+    let entry_tags = vec!["alpha".to_string(), "beta".to_string()];
+    let group_tags = vec!["one".to_string(), "two".to_string()];
+
+    let db = build_db_with_tagged_entry_and_group(entry_tags.clone(), group_tags.clone());
+    let (bytes, _) = save_and_get_xml(&db);
+
+    let parsed = Database::open(&mut bytes.as_slice(), key()).expect("re-open");
+
+    let root = parsed.root();
+    let entry = root.entry_by_name("tagged-entry").expect("entry survived");
+    let group = root.group_by_name("tagged-group").expect("group survived");
+
+    assert_eq!(entry.tags, entry_tags, "entry tags lost during round trip");
+    assert_eq!(group.tags, group_tags, "group tags lost during round trip");
+}
+
+#[test]
+fn reader_accepts_comma_delimited_entry_tags() {
+    // Regression: the entry-tag splitter previously used ',' exclusively.
+    // This test verifies that with the centralized splitter, ','-delimited
+    // tags (as produced by older KeePassXC writers) still parse correctly.
+    let path = std::path::Path::new("tests/resources/test_db_kdbx4_with_password_aes.kdbx");
+    let db =
+        Database::open(&mut std::fs::File::open(path).expect("open fixture"), key()).expect("parse fixture");
+
+    let root = db.root();
+    let entry = root.entry_by_name("ASDF").expect("entry from fixture");
+
+    assert_eq!(
+        entry.tags,
+        vec!["keepass-rs".to_string(), "test".to_string()],
+        "',' delimited entry tags from the KeePassXC fixture must parse into a list",
+    );
+}
+
+#[test]
+fn reader_accepts_semicolon_delimited_group_tags() {
+    // Group tags in `test_db_kdbx41_with_password_aes.kdbx` are stored
+    // `;`-delimited (`a;b;c`). The centralized splitter must keep that
+    // working.
+    let path = std::path::Path::new("tests/resources/test_db_kdbx41_with_password_aes.kdbx");
+    let db =
+        Database::open(&mut std::fs::File::open(path).expect("open fixture"), key()).expect("parse fixture");
+
+    let root = db.root();
+    let group = root.group_by_name("Group with tags").expect("group from fixture");
+
+    assert_eq!(
+        group.tags,
+        vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        "';' delimited group tags from the KeePass fixture must parse into a list",
+    );
+}


### PR DESCRIPTION
Closes #338.

## Summary

This centralizes XML tag parsing and rendering for entries and groups in a new `xml_db::tags` module. The module defines reusable delimiter constants, writes tags with the canonical semicolon delimiter, and reads either semicolons or commas so existing KeePassXC-style fixtures continue to parse.

`Entry::xml_to_db_handle`, `Entry::db_to_xml`, `Group::xml_to_db_handle`, and `Group::db_to_xml` now all use the same helpers. That removes the previous divergence where entries split/joined with commas while groups split/joined with semicolons.

The regression tests cover the issue directly: saved XML now uses semicolons for both entry and group tags, entry/group tags survive a save-open round trip, comma-delimited entry tags still parse from the existing KDBX4 fixture, and semicolon-delimited group tags still parse from the KDBX4.1 fixture.

## Verification

- `cargo fmt --check`
- `cargo test -q --test tag_serialization --features save_kdbx4`
- `cargo test -q tags --features save_kdbx4`
- `cargo test -q --features save_kdbx4`

The full `save_kdbx4` suite passed locally; `keepassxc_cli_lists_our_vault` remains ignored because `keepassxc-cli` is not installed.
