### PR TITLE
fix: invalid crate keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keepass"
 description = "KeePass .kdbx database file parser"
-keywords = ["keepass", "kdbx", "kdb", "password manager"]
+keywords = ["keepass", "kdbx", "kdb", "password"]
 categories = ["parser-implementations", "security"]
 
 edition = "2018"


### PR DESCRIPTION
the crate gets rejected by crates.io because two-word keywords such as "password manager" are disallowed.