### PR TITLE
feat: correct DataTransferObfuscation serialization/deserialization

### DIFF
--- a/src/db/types/autotype.rs
+++ b/src/db/types/autotype.rs
@@ -10,7 +10,7 @@ pub struct AutoType {
 
     /// Whether an implementation MAY try to obfuscate Auto-Type key strokes to make it harder
     /// for key loggers to record the full sequence.
-    pub data_transfer_obfuscation: Option<bool>,
+    pub data_transfer_obfuscation: DataTransferObfuscation,
 
     /// Window associations for this entry. The first association whose window matches the active
     /// window will be used.
@@ -27,4 +27,21 @@ pub struct AutoTypeAssociation {
     /// A custom Auto-Type sequence. If the value is left empty, the sequence from default_sequence is
     /// used or, if that is empty as well, the group or global default.
     pub sequence: String,
+}
+
+/// Obfuscation methods for auto-type data transfer.
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+pub enum DataTransferObfuscation {
+    /// No obfuscation. The auto-type sequence is sent as-is.
+    None,
+
+    /// Obfuscate auto-type sequence using the clipboard
+    UseClipboard,
+}
+
+impl Default for DataTransferObfuscation {
+    fn default() -> Self {
+        Self::None
+    }
 }

--- a/src/db/types/mod.rs
+++ b/src/db/types/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod value;
 use std::collections::HashMap;
 
 pub use attachment::{Attachment, AttachmentId, AttachmentMut, AttachmentRef};
-pub use autotype::{AutoType, AutoTypeAssociation};
+pub use autotype::{AutoType, AutoTypeAssociation, DataTransferObfuscation};
 pub use color::{Color, ParseColorError};
 pub use custom_data::{CustomDataItem, CustomDataValue};
 pub use entry::{DestinationGroupNotFoundError, Entry, EntryId, EntryMut, EntryRef, EntryTrack};

--- a/src/format/xml_db/custom_serde.rs
+++ b/src/format/xml_db/custom_serde.rs
@@ -88,45 +88,6 @@ pub mod cs_opt_bool {
     }
 }
 
-/// Optional boolean serialized as the integer "0"/"1". None maps to "0".
-pub mod cs_opt_intbool {
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(data: &Option<bool>, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match data {
-            Some(b) => s.serialize_str(if *b { "1" } else { "0" }),
-            None => s.serialize_str("0"),
-        }
-    }
-
-    pub fn deserialize<'de, D>(d: D) -> Result<Option<bool>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let opt = Option::<String>::deserialize(d)?;
-        match opt {
-            Some(s) => {
-                let trimmed = s.trim();
-                if trimmed.is_empty() {
-                    Ok(None)
-                } else {
-                    match trimmed {
-                        "1" | "true" | "True" => Ok(Some(true)),
-                        "0" | "false" | "False" => Ok(Some(false)),
-                        _ => Err(serde::de::Error::custom(format!(
-                            "Invalid integer-bool string: {s}"
-                        ))),
-                    }
-                }
-            }
-            None => Ok(None),
-        }
-    }
-}
-
 /// Optional value that implements FromStr that may be missing empty, e.g. numbers
 pub mod cs_opt_fromstr {
     use std::str::FromStr;

--- a/src/format/xml_db/entry.rs
+++ b/src/format/xml_db/entry.rs
@@ -11,7 +11,7 @@ use crate::{
     crypt::{ciphers::Cipher, CryptographyError},
     db::{AttachmentId, Color, EntryId, EntryMut, GroupId},
     format::xml_db::{
-        custom_serde::{cs_bool, cs_opt_bool, cs_opt_fromstr, cs_opt_intbool, cs_opt_string},
+        custom_serde::{cs_bool, cs_opt_bool, cs_opt_fromstr, cs_opt_string},
         meta::CustomData,
         tags::split_tags,
         times::Times,
@@ -326,8 +326,8 @@ pub struct AutoType {
     #[serde(default, with = "cs_bool")]
     pub enabled: bool,
 
-    #[serde(default, with = "cs_opt_intbool", skip_serializing_if = "Option::is_none")]
-    pub data_transfer_obfuscation: Option<bool>,
+    #[serde(default, with = "cs_opt_fromstr", skip_serializing_if = "Option::is_none")]
+    pub data_transfer_obfuscation: Option<usize>,
 
     #[serde(default, with = "cs_opt_string", skip_serializing_if = "Option::is_none")]
     pub default_sequence: Option<String>,
@@ -341,7 +341,10 @@ impl From<AutoType> for crate::db::AutoType {
         crate::db::AutoType {
             enabled: value.enabled,
             default_sequence: value.default_sequence,
-            data_transfer_obfuscation: value.data_transfer_obfuscation,
+            data_transfer_obfuscation: value
+                .data_transfer_obfuscation
+                .map(|d| d.into())
+                .unwrap_or_default(),
             associations: value.associations.into_iter().map(|a| a.into()).collect(),
         }
     }
@@ -351,9 +354,28 @@ impl From<crate::db::AutoType> for AutoType {
     fn from(value: crate::db::AutoType) -> Self {
         Self {
             enabled: value.enabled,
-            data_transfer_obfuscation: value.data_transfer_obfuscation,
+            data_transfer_obfuscation: Some(value.data_transfer_obfuscation.into()),
             default_sequence: value.default_sequence,
             associations: value.associations.into_iter().map(|a| a.into()).collect(),
+        }
+    }
+}
+
+impl From<usize> for crate::db::DataTransferObfuscation {
+    fn from(value: usize) -> Self {
+        match value {
+            0 => Self::None,
+            1 => Self::UseClipboard,
+            _ => Self::None, // default to None for unknown values
+        }
+    }
+}
+
+impl From<crate::db::DataTransferObfuscation> for usize {
+    fn from(value: crate::db::DataTransferObfuscation) -> Self {
+        match value {
+            crate::db::DataTransferObfuscation::None => 0,
+            crate::db::DataTransferObfuscation::UseClipboard => 1,
         }
     }
 }
@@ -488,7 +510,7 @@ mod tests {
 
         let deserialized: Test<AutoType> = quick_xml::de::from_str(xml).unwrap();
         assert!(deserialized.0.enabled);
-        assert!(!deserialized.0.data_transfer_obfuscation.unwrap());
+        assert_eq!(deserialized.0.data_transfer_obfuscation, Some(0));
         assert_eq!(
             deserialized.0.default_sequence.unwrap(),
             "{USERNAME}{TAB}{PASSWORD}{ENTER}"
@@ -499,7 +521,7 @@ mod tests {
     fn test_serialize_autotype() {
         let autotype = AutoType {
             enabled: true,
-            data_transfer_obfuscation: Some(false),
+            data_transfer_obfuscation: Some(0),
             default_sequence: Some("{USERNAME}{TAB}{PASSWORD}{ENTER}".to_string()),
             associations: vec![AutoTypeAssociation {
                 window: "Example Window".to_string(),
@@ -569,7 +591,7 @@ mod tests {
         assert!(deserialized.0.auto_type.is_some());
         let autotype = deserialized.0.auto_type.unwrap();
         assert!(autotype.enabled);
-        assert!(!autotype.data_transfer_obfuscation.unwrap());
+        assert_eq!(autotype.data_transfer_obfuscation, Some(0));
         assert_eq!(
             autotype.default_sequence.unwrap(),
             "{USERNAME}{TAB}{PASSWORD}{ENTER}"

--- a/tests/kdbx41_features.rs
+++ b/tests/kdbx41_features.rs
@@ -10,8 +10,8 @@ use chrono::NaiveDate;
 use keepass::{
     config::{DatabaseConfig, KdfConfig},
     db::{
-        fields, AutoType, AutoTypeAssociation, Color, CustomDataItem, CustomDataValue, CustomIconId, Database,
-        EntryId, GroupId, Value,
+        fields, AutoType, AutoTypeAssociation, Color, CustomDataItem, CustomDataValue, CustomIconId,
+        DataTransferObfuscation, Database, EntryId, GroupId, Value,
     },
     DatabaseKey,
 };
@@ -106,7 +106,7 @@ fn build_kdbx41_rich_database() -> (Database, EntryId) {
         entry.autotype = Some(AutoType {
             enabled: true,
             default_sequence: Some("{USERNAME}{TAB}{PASSWORD}{ENTER}".to_string()),
-            data_transfer_obfuscation: Some(true),
+            data_transfer_obfuscation: DataTransferObfuscation::UseClipboard,
             associations: vec![
                 AutoTypeAssociation {
                     window: "Login - *".to_string(),
@@ -208,7 +208,10 @@ fn entry_autotype_with_obfuscation_round_trips() {
     let entry = root.entry(id).expect("entry survives");
     let at = entry.autotype.as_ref().expect("autotype present");
     assert!(at.enabled);
-    assert_eq!(at.data_transfer_obfuscation, Some(true));
+    assert_eq!(
+        at.data_transfer_obfuscation,
+        DataTransferObfuscation::UseClipboard
+    );
     assert_eq!(at.associations.len(), 2);
     assert_eq!(at.associations[0].window, "Login - *");
 }


### PR DESCRIPTION
The DataTransferObfuscation field in the XML database is serialized as an integer, but corresponds to an enumeration of obfuscation methods[1]. Make the enumeration explicit.

[1] https://github.com/ralish/KeePass/blob/c238e8ee9bb62f4df4e102e67e5a731971a23852/KeePassLib/Collections/AutoTypeConfig.cs#L29-L33