### PR TITLE
chore: bump codecov-action

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           nix develop --command cargo tarpaulin --verbose --timeout 120
       - name: Upload code coverage
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@e79a69670b123597c3b2c6a12226c99827d23dc7 # v6.0.1
         with:
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
I have a feeling that this will fix [those errors](https://github.com/sseemayer/keepass-rs/actions/runs/27070864641/job/79907367746#step:6:276), which I also have a feeling are related to [this announcement](https://www.prnewswire.com/news-releases/harness-acquires-codecov-from-sentry-to-strengthen-software-delivery-governance-in-the-ai-era-302787720.html).

