### PR TITLE
ci: enable github-native code coverage

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -42,6 +42,8 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    permissions:
+      code-quality: write
     steps:
       - uses: actions/checkout@v6
       - name: Get Nix version
@@ -59,6 +61,13 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Post to native GitHub coverage
+        uses: actions/upload-code-coverage@v1
+        continue-on-error: true
+        with:
+          file: cobertura.xml
+          language: rust
+          label: rust-coverage
 
   get-next-version:
     name: Get the next version


### PR DESCRIPTION
I'm not sure it is feature-rich enough to replace codecov just yet but I think it's worth a try
I followed the documentation [here](https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage)