### PR TITLE
Bump quick-xml to 0.41 (RUSTSEC-2026-0194)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ byteorder = "1"
 flate2 = "1"
 base64 = "0.22"
 serde = { version = "1",  features = ["derive"] }
-quick-xml = { version = "0.40", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 hex-literal = "1"
 secrecy = "0.10.3"
 chrono = { version = "0.4.23", default-features = false, features = [


### PR DESCRIPTION
`quick-xml` before `0.41` is affected by [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) — quadratic run time when checking a start tag for duplicate attribute names. keepass parses untrusted KDBX inner XML via quick-xml, so a maliciously crafted database could trigger the quadratic blow-up (DoS).

`0.41.0` fixes the advisory. The bump needs **no source changes** — `cargo build` (default, `save_kdbx4`, and `serialization`+`totp`) and the full test suite (`cargo test --features save_kdbx4,serialization,totp`, 150+ tests) pass unchanged.