### PR TITLE
fix: correct several cross-library compatibility issues

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -352,7 +352,8 @@ impl KdfConfig {
 
         match self {
             KdfConfig::Aes { rounds } => {
-                vd.set(KDF_ID, KDF_AES_KDBX4.to_vec());
+                // always use the KDBX3 AES KDF UUID for compatibility with other libraries
+                vd.set(KDF_ID, KDF_AES_KDBX3.to_vec());
                 vd.set(KDF_ROUNDS, *rounds);
                 vd.set(KDF_SEED, seed.to_vec());
             }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -104,13 +104,23 @@ pub enum ParseXmlKeyFileError {
 fn parse_keyfile(buffer: &[u8]) -> Result<KeyElement, DatabaseKeyError> {
     // try to parse the buffer as XML, if successful, use that data instead of full file
     if let Ok(v) = parse_xml_keyfile(buffer) {
-        Ok(v)
-    } else if buffer.len() == 32 {
-        // legacy binary key format
-        Ok(buffer.to_vec())
-    } else {
-        Ok(calculate_sha256(&[buffer]).as_slice().to_vec())
+        return Ok(v);
     }
+
+    // legacy binary key format
+    if buffer.len() == 32 {
+        return Ok(buffer.to_vec());
+    }
+
+    // legacy hex key format
+    if buffer.len() == 64 {
+        if let Ok(key_bytes) = hex::decode(buffer) {
+            return Ok(key_bytes);
+        }
+    }
+
+    // interpret as a "bare" keyfile and hash the entire file contents
+    Ok(calculate_sha256(&[buffer]).as_slice().to_vec())
 }
 
 /// A KeePass key, which might consist of a password and/or a keyfile

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,8 +13,20 @@ use keepass::{
 
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 
+use sha2::{Digest, Sha256};
+
 pub const MASTER_SEED: u64 = 0xdead_beef_cafe_f00d;
 pub const DEMO_PASSWORD: &str = "demopass";
+
+fn calculate_sha256(elements: &[&[u8]]) -> Vec<u8> {
+    let mut digest = Sha256::new();
+
+    for element in elements {
+        digest.update(element);
+    }
+
+    digest.finalize().to_vec()
+}
 
 #[derive(Debug, Clone)]
 pub struct Combo {
@@ -69,8 +81,13 @@ impl KeyfileKind {
                 };
                 let l1 = line(&hex_lo[0..32]);
                 let l2 = line(&hex_lo[32..64]);
+
+                // hash should be the first 4 bytes of the SHA256 of the keyfile data
+                let hash = calculate_sha256(&[&k[..]]);
+                let hash_hex = hex::encode(&hash[0..4]).to_uppercase();
+
                 format!(
-                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<KeyFile>\n  <Meta><Version>2.0</Version></Meta>\n  <Key>\n    <Data Hash=\"00000000\">\n      {l1}\n      {l2}\n    </Data>\n  </Key>\n</KeyFile>\n"
+                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<KeyFile>\n  <Meta><Version>2.0</Version></Meta>\n  <Key>\n    <Data Hash=\"{hash_hex}\">\n      {l1}\n      {l2}\n    </Data>\n  </Key>\n</KeyFile>\n"
                 )
                 .into_bytes()
             }

--- a/tests/cross_tool.rs
+++ b/tests/cross_tool.rs
@@ -5,80 +5,157 @@
 
 mod common;
 
+use std::fs::File;
 use std::io::Write as _;
 use std::process::{Command, Stdio};
 
-use common::{baseline_combo, DEMO_PASSWORD};
+use common::round_trip_combos;
+
+use crate::common::MasterKey;
 
 #[test_with::executable(kpscript)]
 fn kpscript_lists_our_vault() {
-    let combo = baseline_combo();
-    let db = combo.rich_database();
-    let bytes = common::save_to_vec(&db, combo.get_key());
+    // filter out twofish since KeePass does not support it
+    let combos: Vec<_> = round_trip_combos()
+        .into_iter()
+        .filter(|c| !c.label.contains("twofish") && !c.label.contains("aeskdf"))
+        .collect();
 
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().join("fixture.kdbx");
-    std::fs::write(&path, &bytes).expect("write vault");
+    for combo in combos {
+        println!("Testing combo: {}", combo.label);
 
-    let out = std::process::Command::new("kpscript")
-        .arg("-c:ListEntries")
-        .arg(&path)
-        .arg(format!("-pw:{DEMO_PASSWORD}"))
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .output()
-        .expect("spawn KPScript");
-    if !out.status.success() {
-        panic!(
-            "KPScript ListEntries failed: {} stderr={}",
-            out.status,
-            String::from_utf8_lossy(&out.stderr)
+        let db = combo.rich_database();
+        let bytes = common::save_to_vec(&db, combo.get_key());
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fixture.kdbx");
+        std::fs::write(&path, &bytes).expect("write vault");
+
+        let mut command = Command::new("kpscript");
+
+        let command = command
+            .arg("-c:ListEntries")
+            .arg(&path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let command = match combo.master_key {
+            MasterKey::Password(password) => command.arg(format!("-pw:{password}")),
+            MasterKey::Keyfile(keyfile_kind) => {
+                let keyfile_path = dir.path().join("keyfile");
+                let mut file = File::create(&keyfile_path).expect("create temp keyfile");
+                file.write_all(&keyfile_kind.to_bytes()).expect("write keyfile");
+
+                command.arg(format!("-keyfile:{}", keyfile_path.display()))
+            }
+            MasterKey::PasswordAndKeyfile(password, keyfile_kind) => {
+                let keyfile_path = dir.path().join("keyfile");
+                let mut file = File::create(&keyfile_path).expect("create temp keyfile");
+                file.write_all(&keyfile_kind.to_bytes()).expect("write keyfile");
+
+                command
+                    .arg(format!("-keyfile:{}", keyfile_path.display()))
+                    .arg(format!("-pw:{password}"))
+            }
+        };
+
+        println!("Running command: {:?}", command);
+
+        let out = command.output().expect("spawn KPScript");
+
+        if !out.status.success() {
+            let _ = dir.keep();
+            panic!(
+                "KPScript ListEntries failed: {} stderr={}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("entry-"),
+            "KPScript output didn't list our entries: {:?}",
+            stdout
         );
     }
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(
-        stdout.contains("entry-"),
-        "KPScript output didn't list our entries: {:?}",
-        stdout
-    );
 }
 
 #[test_with::executable(keepassxc-cli)]
 fn keepassxc_cli_lists_our_vault() {
-    let combo = baseline_combo();
-    let db = combo.rich_database();
-    let bytes = common::save_to_vec(&db, combo.get_key());
+    let combos: Vec<_> = round_trip_combos().into_iter().collect();
 
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().join("fixture.kdbx");
-    std::fs::write(&path, &bytes).expect("write vault");
+    for combo in combos {
+        println!("Testing combo: {}", combo.label);
 
-    let mut child = Command::new("keepassxc-cli")
-        .arg("ls")
-        .arg(&path)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn keepassxc-cli");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(format!("{DEMO_PASSWORD}\n").as_bytes())
-        .expect("write password");
-    let out = child.wait_with_output().expect("wait keepassxc-cli");
-    if !out.status.success() {
-        panic!(
-            "keepassxc-cli ls failed: {} stderr={}",
-            out.status,
-            String::from_utf8_lossy(&out.stderr)
+        let db = combo.rich_database();
+
+        let bytes = common::save_to_vec(&db, combo.get_key());
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fixture.kdbx");
+        std::fs::write(&path, &bytes).expect("write vault");
+
+        let mut command = Command::new("keepassxc-cli");
+
+        let command = command
+            .arg("ls")
+            .arg(&path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let (command, password) = match combo.master_key {
+            MasterKey::Password(password) => (command, Some(password)),
+            MasterKey::Keyfile(keyfile_kind) => {
+                let keyfile_path = dir.path().join("keyfile");
+                let mut file = File::create(&keyfile_path).expect("create temp keyfile");
+                file.write_all(&keyfile_kind.to_bytes()).expect("write keyfile");
+
+                let command = command.arg("--key-file").arg(keyfile_path).arg("--no-password");
+
+                (command, None)
+            }
+            MasterKey::PasswordAndKeyfile(password, keyfile_kind) => {
+                let keyfile_path = dir.path().join("keyfile");
+                let mut file = File::create(&keyfile_path).expect("create temp keyfile");
+                file.write_all(&keyfile_kind.to_bytes()).expect("write keyfile");
+
+                let command = command.arg("--key-file").arg(keyfile_path);
+
+                (command, Some(password))
+            }
+        };
+
+        if password.is_some() {
+            command.stdin(Stdio::piped());
+        }
+
+        println!("Running command: {:?}", command);
+
+        let mut child = command.spawn().expect("spawn keepassxc-cli");
+
+        if let Some(password) = password {
+            child
+                .stdin
+                .as_mut()
+                .unwrap()
+                .write_all(format!("{password}\n").as_bytes())
+                .expect("write password");
+        }
+
+        let out = child.wait_with_output().expect("wait keepassxc-cli");
+        if !out.status.success() {
+            let _ = dir.keep();
+            panic!(
+                "keepassxc-cli ls failed: {} stderr={}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("entry-"),
+            "keepassxc-cli output didn't list our entries: {:?}",
+            stdout
         );
     }
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(
-        stdout.contains("entry-"),
-        "keepassxc-cli output didn't list our entries: {:?}",
-        stdout
-    );
 }

--- a/tests/cross_tool.rs
+++ b/tests/cross_tool.rs
@@ -18,7 +18,7 @@ fn kpscript_lists_our_vault() {
     // filter out twofish since KeePass does not support it
     let combos: Vec<_> = round_trip_combos()
         .into_iter()
-        .filter(|c| !c.label.contains("twofish") && !c.label.contains("aeskdf"))
+        .filter(|c| !c.label.contains("twofish"))
         .collect();
 
     for combo in combos {


### PR DESCRIPTION
closes #357 

- this crate was using a non-spec-compliant UUID to denote the AES Key Derivation function. Now use the standard UUID of C9D9F39A628A4460BF740D08C18A4FEA when dumping databases
- add missing support for legacy hex keyfiles
- extend the cross-tool tests to perform matrix testing on different DatabaseConfig combinations, ensuring the resulting databases can be parsed by keepass and keepassxc