### PR TITLE
ci: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757793750,
-        "narHash": "sha256-CmdO/FZSRA+p0Tpq0o8loNpmTIIVTTErDoqhW82gtas=",
+        "lastModified": 1783278169,
+        "narHash": "sha256-2DZUS8cvTstP6hN71mvrOcIHGT69X47JgSTtndt2p9M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fc59955d9232318cc860d500d9add044fa2c52b1",
+        "rev": "4a18a3f445f488881474c5ad7865cbc8595416c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The test-with crate version 0.16.4 increases its MSRV to 1.95.0, so update the flake.lock to pull in a new rust compiler.