### PR TITLE
feat(ci): report code coverage changes on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,12 @@ jobs:
       - name: Generate code coverage
         run: |
           nix develop --command cargo tarpaulin --verbose --timeout 120
+      - name: Upload code coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          fail_ci_if_error: false
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   wasm32-tests:
     name: WASM32 Tests (Node)


### PR DESCRIPTION
Closes #261.

This adds the missing upload step so Codecov posts the coverage comment and status on each PR:

Two deliberate choices for the PR context:

- fail_ci_if_error: false — a Codecov outage, or a PR from an external fork that has no CODECOV_TOKEN, must not fail every contributor's build. merge.yml keeps its strict fail_ci_if_error: true on master.
- Passing token still works for same-repo PRs; external-fork PRs fall back to Codecov tokenless upload for public repos.

Verified on my fork (SchnitzelAndSpaetzle/keepass-rs#9): the PR's Code Coverage job uploads successfully, and Codecov comments on the PR. 

