### PR TITLE
feat: make ID constructors public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ chrono = { version = "0.4.23", default-features = false, features = [
 rust-argon2 = "3.0"
 sha1 = { version = "0.11", optional = true }
 sha2 = "0.11"
-aes = "0.9"
+aes = "<0.9.3"
 block-modes = "0.9"
 hmac = "0.13"
 salsa20 = "0.11"

--- a/src/db/types/entry.rs
+++ b/src/db/types/entry.rs
@@ -22,7 +22,8 @@ use crate::{
 pub struct EntryId(Uuid);
 
 impl EntryId {
-    pub(crate) fn new() -> Self {
+    /// Generate a new random `EntryId`.
+    pub fn new() -> Self {
         Self(Uuid::new_v4())
     }
 
@@ -844,10 +845,16 @@ impl Drop for EntryTrack<'_> {
 #[allow(clippy::unwrap_used)]
 mod tests {
 
+    use super::EntryId;
     use crate::{
         db::{fields, Value},
         Database,
     };
+
+    #[test]
+    fn entry_id_new_generates_distinct_ids() {
+        assert_ne!(EntryId::new(), EntryId::new());
+    }
 
     #[test]
     fn test_entry() {

--- a/src/db/types/group.rs
+++ b/src/db/types/group.rs
@@ -21,7 +21,8 @@ use crate::{
 pub struct GroupId(Uuid);
 
 impl GroupId {
-    pub(crate) fn new() -> Self {
+    /// Generate a new random `GroupId`.
+    pub fn new() -> Self {
         Self(Uuid::new_v4())
     }
 
@@ -943,6 +944,13 @@ mod group_tests {
             db.root_mut().add_group_with_id(pinned),
             Err(DuplicateGroupIdError(gid)) if gid == pinned
         ));
+    }
+
+    #[test]
+    fn group_id_new_generates_distinct_ids() {
+        use crate::db::GroupId;
+
+        assert_ne!(GroupId::new(), GroupId::new());
     }
 
     #[test]

--- a/src/db/types/group.rs
+++ b/src/db/types/group.rs
@@ -20,7 +20,8 @@ use crate::{
 pub struct GroupId(Uuid);
 
 impl GroupId {
-    pub(crate) fn new() -> Self {
+    /// Generate a new random `GroupId`.
+    pub fn new() -> Self {
         Self(Uuid::new_v4())
     }
 
@@ -942,6 +943,13 @@ mod group_tests {
             db.root_mut().add_group_with_id(pinned),
             Err(DuplicateGroupIdError(gid)) if gid == pinned
         ));
+    }
+
+    #[test]
+    fn group_id_new_generates_distinct_ids() {
+        use crate::db::GroupId;
+
+        assert_ne!(GroupId::new(), GroupId::new());
     }
 
     #[test]


### PR DESCRIPTION
This allows creating new IDs without having to import the `uuid` crate.