### PR TITLE
feat: preserve group and entry insertion order in group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ cbc = "0.2"
 challenge_response = { version = "0.5", optional = true, default-features = false, features = ["nusb"] }
 
 uuid = { version = "1.18.1", features = ["v4", "serde"] }
+indexmap = { version = "2", features = ["serde"] }
 hex = { version = "0.4" }
 hybrid-array = "0.4"
 getrandom = { version = "0.4", features = ["std"] }

--- a/src/db/types/entry.rs
+++ b/src/db/types/entry.rs
@@ -586,7 +586,7 @@ impl EntryMut<'_> {
         let previous_parent = self.parent;
 
         let mut parent = self.parent_mut();
-        parent.entries.remove(&my_id);
+        parent.entries.shift_remove(&my_id);
 
         #[allow(clippy::unwrap_used, clippy::missing_panics_doc)] // group existence is checked
         let mut new_parent = self.database.group_mut(group_id).unwrap();
@@ -635,7 +635,7 @@ impl EntryMut<'_> {
             .database
             .group_mut(entry.parent)
             .expect("Parent group not found");
-        parent.entries.remove(&self.id);
+        parent.entries.shift_remove(&self.id);
 
         // Clear any group's last_top_visible_entry that pointed to this entry.
         // This field is a UI hint and should not hold a dangling EntryId.

--- a/src/db/types/group.rs
+++ b/src/db/types/group.rs
@@ -3,6 +3,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use indexmap::IndexSet;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -74,10 +75,10 @@ pub struct Group {
     pub(crate) icon: Option<Icon>,
 
     /// The list of child group identifiers
-    pub(crate) groups: HashSet<GroupId>,
+    pub(crate) groups: IndexSet<GroupId>,
 
     /// The list of entry identifiers directly under this group
-    pub(crate) entries: HashSet<EntryId>,
+    pub(crate) entries: IndexSet<EntryId>,
 
     /// The list of time fields for this group
     pub times: Times,
@@ -117,8 +118,8 @@ impl Group {
             notes: None,
             tags: Vec::new(),
             icon: None,
-            groups: HashSet::new(),
-            entries: HashSet::new(),
+            groups: IndexSet::new(),
+            entries: IndexSet::new(),
             times: Times::new(),
             custom_data: HashMap::new(),
             is_expanded: true,
@@ -138,8 +139,8 @@ impl Group {
             notes: None,
             tags: Vec::new(),
             icon: None,
-            groups: HashSet::new(),
-            entries: HashSet::new(),
+            groups: IndexSet::new(),
+            entries: IndexSet::new(),
             times: Times::new(),
             custom_data: HashMap::new(),
             is_expanded: true,
@@ -570,7 +571,7 @@ impl GroupMut<'_> {
         // Remove from old parent
         #[allow(clippy::unwrap_used, clippy::missing_panics_doc)] // we checked that old_parent_id exists
         let mut old_parent = self.database.group_mut(old_parent_id).unwrap();
-        old_parent.groups.remove(&self.id);
+        old_parent.groups.shift_remove(&self.id);
 
         // Insert into new parent
         #[allow(clippy::unwrap_used, clippy::missing_panics_doc)] // we checked that new_parent_id exists
@@ -593,7 +594,7 @@ impl GroupMut<'_> {
         // Remove from parent
         if let Some(parent_id) = self.parent {
             if let Some(mut parent) = self.database.group_mut(parent_id) {
-                parent.groups.remove(&self.id);
+                parent.groups.shift_remove(&self.id);
             }
         }
 
@@ -725,7 +726,7 @@ impl GroupTrack<'_> {
         // Remove from parent
         if let Some(parent_id) = self.parent {
             if let Some(mut parent) = self.database.group_mut(parent_id) {
-                parent.groups.remove(&self.id);
+                parent.groups.shift_remove(&self.id);
             }
         }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -336,3 +336,10 @@ pub fn save_to_vec(db: &Database, key: DatabaseKey) -> Vec<u8> {
     db.save(&mut buf, key).expect("save_to_vec: save failed");
     buf
 }
+
+#[cfg(feature = "save_kdbx4")]
+pub fn save_then_open(db: &Database, key: DatabaseKey) -> Database {
+    let mut buf = Vec::new();
+    db.save(&mut buf, key.clone()).expect("Unable to save database");
+    Database::open(&mut buf.as_slice(), key).expect("Unable to open database")
+}

--- a/tests/ordering_tests.rs
+++ b/tests/ordering_tests.rs
@@ -1,0 +1,115 @@
+//! Regression test for preserving groups and entries order across save/open.
+#![cfg(feature = "save_kdbx4")]
+
+mod common;
+
+use crate::common::{save_then_open, DEMO_PASSWORD};
+use keepass::{db::fields, Database, DatabaseKey};
+
+#[test]
+fn group_and_entry_order_should_survive_round_trip() {
+    let db = setup_database();
+    let key = DatabaseKey::new().with_password(DEMO_PASSWORD);
+
+    // Write database to byte array and read it
+    let actual = save_then_open(&db, key);
+
+    // Read entries and groups
+    let root = actual.root();
+    let actual_group_titles = root.groups().map(|g| g.name.to_string()).collect::<Vec<String>>();
+    let actual_entry_titles = root
+        .entries()
+        .map(|e| e.get_title().unwrap_or("").to_string())
+        .collect::<Vec<String>>();
+
+    // Check titles are in correct order
+    assert_eq!(actual_group_titles, generate_group_titles());
+    assert_eq!(actual_entry_titles, generate_entry_titles());
+}
+
+#[test]
+fn group_and_entry_order_should_survive_round_trip_after_deletion() {
+    let mut db = setup_database();
+    let key = DatabaseKey::new().with_password(DEMO_PASSWORD);
+
+    // Delete some of the groups and entries
+    let deleted_group_indexes = [0, 8, 19];
+    let deleted_entry_indexes = [0, 7, 19];
+
+    let group_ids = db.root().groups().map(|group| group.id()).collect::<Vec<_>>();
+    let entry_ids = db.root().entries().map(|entry| entry.id()).collect::<Vec<_>>();
+
+    for deleted_group_index in deleted_group_indexes {
+        db.group_mut(group_ids[deleted_group_index])
+            .expect("group should exist")
+            .remove()
+    }
+
+    for deleted_entry_index in deleted_entry_indexes {
+        db.entry_mut(entry_ids[deleted_entry_index])
+            .expect("entry should exist")
+            .remove();
+    }
+
+    // Write database to byte array and read it
+    let actual = save_then_open(&db, key);
+
+    // Read entries and groups
+    let root = actual.root();
+    let actual_group_titles = root.groups().map(|g| g.name.to_string()).collect::<Vec<String>>();
+    let actual_entry_titles = root
+        .entries()
+        .map(|e| e.get_title().unwrap_or("").to_string())
+        .collect::<Vec<String>>();
+
+    // Check titles are in correct order
+    assert_eq!(
+        actual_group_titles,
+        filter_indexes(generate_group_titles(), &deleted_group_indexes),
+    );
+    assert_eq!(
+        actual_entry_titles,
+        filter_indexes(generate_entry_titles(), &deleted_entry_indexes),
+    );
+}
+
+fn generate_entry_titles() -> Vec<String> {
+    (0..20)
+        .into_iter()
+        .map(|index| format!("Entry_{index}"))
+        .collect()
+}
+
+fn generate_group_titles() -> Vec<String> {
+    (0..20)
+        .into_iter()
+        .map(|index| format!("Group_{index}"))
+        .collect()
+}
+
+fn setup_database() -> Database {
+    let mut db = Database::new();
+    let mut root = db.root_mut();
+
+    let entry_titles = generate_entry_titles();
+    let group_titles = generate_group_titles();
+
+    for entry_title in &entry_titles {
+        let mut entry = root.add_entry();
+        entry.set_unprotected(fields::TITLE, entry_title);
+    }
+    for group_title in &group_titles {
+        let mut group = root.add_group();
+        group.name = group_title.to_string();
+    }
+
+    db
+}
+
+fn filter_indexes(titles: Vec<String>, indexes: &[usize]) -> Vec<String> {
+    titles
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, title)| (!indexes.contains(&index)).then_some(title))
+        .collect()
+}


### PR DESCRIPTION
**Description of issue**
The order of groups and entries written in XML is determined by function `db_to_xml`, that iterates over `Group.groups` and `Groups.entries`. The previous implementation kept child group and entry IDs in `HashSet`s, so iteration order was not guaranteed. As a result, save/open round trips could reorder groups or entries even when no user-visible ordering change was intended.

**Description of changes**
`HashSet` were replaced with `IndexSet`.

Tests were added to check:
- root entry order survives saving and reopening
- order is still preserved after deleting selected groups and entries

_As I’m still new to Rust, so I’d really appreciate any feedback or suggestions._