### PR TITLE
feat: preserve empty fields as is in original database

### DIFF
--- a/src/format/xml_db/entry.rs
+++ b/src/format/xml_db/entry.rs
@@ -103,18 +103,17 @@ impl Entry {
         target.times = self.times.map(|t| t.into()).unwrap_or_default();
 
         for field in self.string_fields {
-            if let Some(fval) = &field.value.value {
-                let value = if field.value.protected {
-                    let fval = base64_engine::STANDARD.decode(fval)?;
-                    let fval = inner_decryptor.decrypt(&fval)?;
-                    let fval = String::from_utf8_lossy(&fval).to_string();
+            let fval = field.value.value.unwrap_or_default();
+            let value = if field.value.protected {
+                let fval = base64_engine::STANDARD.decode(fval)?;
+                let fval = inner_decryptor.decrypt(&fval)?;
+                let fval = String::from_utf8_lossy(&fval).to_string();
 
-                    crate::db::Value::protected(fval)
-                } else {
-                    crate::db::Value::unprotected(fval)
-                };
-                target.fields.insert(field.key, value);
-            }
+                crate::db::Value::protected(fval)
+            } else {
+                crate::db::Value::unprotected(fval)
+            };
+            target.fields.insert(field.key, value);
         }
 
         for field in self.binary_fields {

--- a/tests/empty_fields_preservation.rs
+++ b/tests/empty_fields_preservation.rs
@@ -1,0 +1,74 @@
+//! Regression tests for empty entry fields.
+//! Some KeePass implementations may add or remove empty entry fields.
+//! To preserve the original database structure, a round trip should retain
+//! explicitly present empty fields and shouldn't
+//! add empty default fields (UserName, Password, etc.).
+#![cfg(feature = "save_kdbx4")]
+
+mod common;
+
+use crate::common::{save_then_open, DEMO_PASSWORD};
+use keepass::{db::fields, Database, DatabaseKey};
+
+const ENTRY_TITLE: &str = "DemoEntry";
+
+#[test]
+fn empty_entry_fields_should_survive_round_trip() {
+    let db = create_database_with_empty_fields();
+    let key = DatabaseKey::new().with_password(DEMO_PASSWORD);
+
+    // Write database to byte array and read it
+    let actual = save_then_open(&db, key);
+
+    // Empty standard and custom fields should be present after parsing
+    let root = actual.root();
+    let entry = root
+        .entry_by_name(ENTRY_TITLE)
+        .expect(format!("Entry '{ENTRY_TITLE}' should present in database").as_str());
+
+    assert_eq!(entry.get(fields::USERNAME), Some(""));
+    assert_eq!(entry.get("CustomField"), Some(""));
+}
+
+#[test]
+fn empty_default_fields_should_not_be_added_after_round_trip() {
+    let db = create_database_without_empty_fields();
+    let key = DatabaseKey::new().with_password(DEMO_PASSWORD);
+
+    // Write database to byte array and read it
+    let actual = save_then_open(&db, key);
+
+    // Entry should not have empty default fields
+    let root = actual.root();
+    let entry = root
+        .entry_by_name(ENTRY_TITLE)
+        .expect(format!("Entry '{ENTRY_TITLE}' should present in database").as_str());
+
+    assert_eq!(entry.get(fields::USERNAME), None);
+    assert_eq!(entry.get(fields::PASSWORD), None);
+    assert_eq!(entry.get(fields::URL), None);
+    assert_eq!(entry.get(fields::NOTES), None);
+}
+
+fn create_database_with_empty_fields() -> Database {
+    let mut db = Database::new();
+    let mut root = db.root_mut();
+    let mut entry = root.add_entry();
+
+    // Add standard KeePass field and custom field.
+    entry.set_unprotected(fields::TITLE, ENTRY_TITLE);
+    entry.set_unprotected(fields::USERNAME, "");
+    entry.set_unprotected("CustomField", "");
+
+    db
+}
+
+fn create_database_without_empty_fields() -> Database {
+    let mut db = Database::new();
+    let mut root = db.root_mut();
+    let mut entry = root.add_entry();
+
+    entry.set_unprotected(fields::TITLE, ENTRY_TITLE);
+
+    db
+}

--- a/tests/entry_tests.rs
+++ b/tests/entry_tests.rs
@@ -52,7 +52,7 @@ mod entry_tests {
         assert_eq!(e.get_title(), Some("test entry"));
         assert_eq!(e.get_username(), Some("jdoe"));
         assert_eq!(e.get_password(), Some("nWuu5AtqsxqNhnYgLwoB"));
-        assert_eq!(e.get_url(), None);
+        assert_eq!(e.get_url(), Some(""));
         assert_eq!(e.times.expires, Some(false));
 
         if let Some(t) = e.times.expiry {


### PR DESCRIPTION
**Description of issue:**
Some KeePass implementations may add or remove empty entry fields. During XML parsing, fields represented by a self-closing `<Value/>` element were treated as absent and omitted from the database. This results in cycle of removing and adding empty fields again to all database entries.

**Description of changes:**
Updated entry parsing to preserve explicitly present empty fields as empty strings.

**Added regression tests covering:**
Preservation of empty standard and custom fields.
Absence of default fields that were not present originally.